### PR TITLE
[round-4] 쿠폰 설계 및 동시성 테스트

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCriteria.java
@@ -1,14 +1,57 @@
 package com.loopers.application.order.dto;
 
-import com.loopers.domain.order.OrderItemModel;
+import com.loopers.domain.order.dto.OrderCommand;
+import com.loopers.domain.product.dto.sku.ProductSkuCommand;
+import com.loopers.domain.product.dto.sku.ProductSkuInfo;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public record OrderCriteria() {
 
     public record Order(
         Long userId,
-        List<OrderItemModel> items
+        List<OrderItem> orderItems,
+        Long couponId
     ) {
+
+        public OrderCommand.Order toOrderCommand(List<ProductSkuInfo> productSkuInfos) {
+            Map<Long, Long> productQuantities = orderItems.stream()
+                .collect(Collectors.toMap(OrderItem::skuId, OrderItem::quantity));
+
+            List<OrderCommand.Order.OrderItem> items = productSkuInfos.stream()
+                .map(productInfo -> new OrderCommand.Order.OrderItem(
+                    productQuantities.get(productInfo.id()),
+                    productInfo.price(),
+                    productInfo.id()
+                ))
+                .toList();
+
+            return new OrderCommand.Order(userId, items);
+        }
+
+
+        public ProductSkuCommand.GetValidSku toProductCommand() {
+            return new ProductSkuCommand.GetValidSku(
+                orderItems.stream().map(OrderItem::toProductOption).toList()
+            );
+        }
+
+        private List<Long> getProductIds() {
+            return orderItems.stream()
+                .map(item -> item.skuId)
+                .toList();
+        }
+
+        public record OrderItem(
+            Long skuId,
+            Long quantity
+        ) {
+            public ProductSkuCommand.OrderSku toProductOption() {
+                return new ProductSkuCommand.OrderSku(skuId, quantity);
+            }
+        }
     }
+
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/DiscountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/DiscountPolicy.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.coupone;
+
+public interface DiscountPolicy {
+    Long calculateDiscount(Long originalPrice);
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/DiscountPolicyFactory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/DiscountPolicyFactory.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.coupone;
+
+
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+
+public class DiscountPolicyFactory {
+    public static DiscountPolicy createFrom(CouponPolicyModel policy) {
+        return switch (policy.getDiscountType()) {
+            case FIXED_AMOUNT -> new FixedAmountDiscount(policy);
+            case PERCENTAGE -> new PercentageDiscount(policy);
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/FixedAmountDiscount.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/FixedAmountDiscount.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.coupone;
+
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+
+public class FixedAmountDiscount implements DiscountPolicy {
+
+    private final Long discountAmount;
+    private final Integer maximumDiscountAmount;
+
+    public FixedAmountDiscount(CouponPolicyModel policy) {
+        this.discountAmount = policy.getDiscountValue().getDiscountValue().longValue();
+        this.maximumDiscountAmount = policy.getOrderAmountCondition().getMaximumDiscountAmount();
+    }
+
+    @Override
+    public Long calculateDiscount(Long originalPrice) {
+        return Math.min(discountAmount,
+            maximumDiscountAmount != null ? maximumDiscountAmount : discountAmount);
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/PercentageDiscount.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/PercentageDiscount.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.coupone;
+
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class PercentageDiscount implements DiscountPolicy {
+    private final BigDecimal discountRate;
+    private final Integer maximumDiscountAmount;
+
+    public PercentageDiscount(CouponPolicyModel policy) {
+        this.discountRate = policy.getDiscountValue().getDiscountValue();
+        this.maximumDiscountAmount = policy.getOrderAmountCondition().getMaximumDiscountAmount();
+    }
+
+    @Override
+    public Long calculateDiscount(Long originalPrice) {
+        BigDecimal discount = BigDecimal.valueOf(originalPrice)
+            .multiply(discountRate)
+            .divide(BigDecimal.valueOf(100), RoundingMode.HALF_DOWN);
+
+        Long calculatedDiscount = discount.longValue();
+        return maximumDiscountAmount != null ?
+            Math.min(calculatedDiscount, maximumDiscountAmount) : calculatedDiscount;
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/dto/CouponCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/dto/CouponCommand.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.coupone.dto;
+
+
+import com.loopers.domain.coupone.enums.CouponStatus;
+
+public record CouponCommand (){
+
+    public record IssueCoupon(
+        Long couponPolicyId,
+        Long userId
+    ) {
+    }
+
+    public record UseCoupon(
+        Long couponId,
+        Long orderId,
+        Long userId
+    ) {
+    }
+
+    public record  GetMyCoupons(
+        Integer page,
+        Integer size,
+        Long userId
+    ){
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/dto/CouponInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/dto/CouponInfo.java
@@ -1,0 +1,30 @@
+package com.loopers.domain.coupone.dto;
+
+import com.loopers.domain.coupone.entity.CouponModel;
+import com.loopers.domain.coupone.enums.CouponStatus;
+import java.time.LocalDateTime;
+
+public record CouponInfo (
+    Long id,
+    Long refCouponPolicyId,
+    Long refUserId,
+    Long orderId,
+    CouponStatus couponStatus,
+    LocalDateTime issuedAt,
+    LocalDateTime expirationTime
+
+){
+    public static CouponInfo from(
+        CouponModel coupon
+    ){
+        return new CouponInfo(
+            coupon.getId(),
+            coupon.getRefCouponPolicyId(),
+            coupon.getRefUserId(),
+            coupon.getOrderId(),
+            coupon.getCouponStatus(),
+            coupon.getUsagePeriod().getIssuedAt(),
+            coupon.getUsagePeriod().getExpirationTime()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/dto/CouponPolicyCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/dto/CouponPolicyCommand.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.coupone.dto;
+
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import com.loopers.domain.coupone.enums.DiscountType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record CouponPolicyCommand(){
+
+    public record Create(
+        String name,
+        String description,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        DiscountType discountType,
+        Long totalQuantity,
+        Integer minimumOrderAmount,
+        Integer maximumDiscountAmount,
+        BigDecimal discountValue,
+        Long remainQuantity
+    ) {
+        public CouponPolicyModel toEntity(){
+            return  CouponPolicyModel.of(name, description, startTime, endTime, discountType, totalQuantity, minimumOrderAmount, maximumDiscountAmount, discountValue, remainQuantity);
+        }
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/entity/CouponModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/entity/CouponModel.java
@@ -1,0 +1,91 @@
+package com.loopers.domain.coupone.entity;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.coupone.enums.CouponStatus;
+import com.loopers.domain.coupone.vo.UsagePeriod;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "coupon")
+public class CouponModel extends BaseEntity {
+
+    @Column(name = "ref_coupon_policy_id", nullable = false)
+    private Long refCouponPolicyId;
+
+    @Column(name = "ref_user_id", nullable = false)
+    private Long refUserId;
+
+    @Column(name = "ref_order_id")
+    private Long orderId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CouponStatus couponStatus;
+
+    @Embedded
+    private UsagePeriod usagePeriod;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+
+    private CouponModel(Long refCouponPolicyId, Long refUserId, CouponStatus couponStatus, LocalDateTime issuedAt,
+        LocalDateTime expirationTime) {
+        if (refCouponPolicyId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "주문 ID는 필수 값입니다.");
+        }
+
+        if (refUserId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "회원 ID는 필수 값입니다.");
+        }
+
+        if (couponStatus == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 상태는 필수 값입니다.");
+        }
+
+        this.couponStatus = couponStatus;
+        this.refCouponPolicyId = refCouponPolicyId;
+        this.refUserId = refUserId;
+        this.usagePeriod = UsagePeriod.of(issuedAt, expirationTime);
+    }
+
+    public static CouponModel of(Long refCouponPolicyId, Long refUserId, CouponStatus couponStatus, LocalDateTime issuedAt,
+        LocalDateTime expirationTime) {
+        return new CouponModel(refCouponPolicyId, refUserId, couponStatus, issuedAt, expirationTime);
+    }
+
+    public boolean isUsed() {
+        return couponStatus == CouponStatus.USED;
+    }
+
+    public boolean isExpired() {
+        LocalDateTime now = LocalDateTime.now();
+        return now.isAfter(usagePeriod.getExpirationTime());
+    }
+
+    public void use(Long orderId) {
+        if (isUsed()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이미 사용한 쿠폰입니다.");
+        }
+        if (isExpired()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "만료된 쿠폰입니다.");
+        }
+        this.couponStatus = CouponStatus.USED;
+        this.orderId = orderId;
+        this.usedAt = LocalDateTime.now();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/entity/CouponPolicyModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/entity/CouponPolicyModel.java
@@ -1,0 +1,83 @@
+package com.loopers.domain.coupone.entity;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.common.vo.Quantity;
+import com.loopers.domain.coupone.enums.DiscountType;
+import com.loopers.domain.coupone.vo.CouponPeriod;
+import com.loopers.domain.coupone.vo.CouponPolicyName;
+import com.loopers.domain.coupone.vo.DiscountValue;
+import com.loopers.domain.coupone.vo.OrderAmountCondition;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "coupon_policy")
+public class CouponPolicyModel extends BaseEntity {
+
+    @Column(nullable = false)
+    private CouponPolicyName name;
+
+    @Column
+    private String description;
+
+    @Embedded
+    private CouponPeriod couponPeriod;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DiscountType discountType;
+
+    @Embedded
+    @AttributeOverride(name = "quantity", column = @Column(name = "total_quantity", nullable = false))
+    private Quantity totalQuantity;
+
+    @Embedded
+    private OrderAmountCondition orderAmountCondition;
+
+    @Embedded
+    private DiscountValue discountValue;
+
+    @Embedded
+    @AttributeOverride(name = "quantity", column = @Column(name = "remain_quantity", nullable = false))
+    private Quantity remainQuantity;
+
+    private CouponPolicyModel(String name, String description, LocalDateTime startTime, LocalDateTime endTime,
+        DiscountType discountType, Long totalQuantity, Integer minimumOrderAmount, Integer maximumDiscountAmount
+        , BigDecimal discountValue, Long remainQuantity) {
+
+        if (discountType == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "할인 유형은 필수 값입니다.");
+        }
+
+        this.name = CouponPolicyName.of(name);
+        this.description = description;
+        this.couponPeriod = CouponPeriod.of(startTime, endTime);
+        this.discountType = discountType;
+        this.totalQuantity = Quantity.of(totalQuantity);
+        this.orderAmountCondition = OrderAmountCondition.of(minimumOrderAmount, maximumDiscountAmount);
+        this.discountValue = DiscountValue.of(discountValue);
+        this.remainQuantity = Quantity.of(remainQuantity);
+    }
+
+    public static CouponPolicyModel of(String name, String description, LocalDateTime startTime, LocalDateTime endTime,
+        DiscountType discountType, Long totalQuantity, Integer minimumOrderAmount, Integer maximumDiscountAmount
+        , BigDecimal discountValue, Long remainQuantity) {
+        return new CouponPolicyModel(name, description, startTime, endTime, discountType, totalQuantity, minimumOrderAmount,
+            maximumDiscountAmount, discountValue, remainQuantity);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/enums/CouponStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/enums/CouponStatus.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.coupone.enums;
+
+public enum CouponStatus {
+    AVAILABLE,    // 사용 가능
+    USED,         // 사용됨
+    EXPIRED,      // 만료됨
+    CANCELED      // 취소됨
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/enums/DiscountType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/enums/DiscountType.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.coupone.enums;
+
+public enum DiscountType {
+    FIXED_AMOUNT,    // 정액 할인
+    PERCENTAGE       // 정률 할인
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/repository/CouponPolicyRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/repository/CouponPolicyRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.coupone.repository;
+
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import java.util.Optional;
+
+public interface CouponPolicyRepository {
+
+    CouponPolicyModel save(CouponPolicyModel couponPolicyModel);
+
+    Optional<CouponPolicyModel> find(Long id);
+
+    Optional<CouponPolicyModel> findWithLock(Long id);
+
+    int decreaseRemainQuantity(Long id);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/repository/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/repository/CouponRepository.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.coupone.repository;
+
+import com.loopers.domain.coupone.entity.CouponModel;
+import com.loopers.support.pagenation.PageResult;
+import java.util.Optional;
+
+public interface CouponRepository {
+
+    CouponModel save(CouponModel coupon);
+
+    Optional<CouponModel> find(Long id);
+
+    Long countByCouponPolicyId(Long id);
+
+    Optional<CouponModel> findByIdAndUserId(Long id, Long userId);
+
+    Optional<CouponModel> findWithLockByIdAndRefUserId(Long id, Long userId);
+
+    PageResult<CouponModel> findUserCoupon(Long userId, Integer page, Integer size);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/service/CouponPolicyService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/service/CouponPolicyService.java
@@ -1,0 +1,30 @@
+package com.loopers.domain.coupone.service;
+
+
+import com.loopers.domain.coupone.dto.CouponPolicyCommand;
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import com.loopers.domain.coupone.repository.CouponPolicyRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponPolicyService {
+
+    private final CouponPolicyRepository couponPolicyRepository;
+
+    @Transactional
+    public CouponPolicyModel create(CouponPolicyCommand.Create command) {
+        CouponPolicyModel policyModel = command.toEntity();
+        return couponPolicyRepository.save(policyModel);
+    }
+
+    @Transactional(readOnly = true)
+    public CouponPolicyModel getCouponPolicy(Long id) {
+        return couponPolicyRepository.find(id)
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰 정책을 찾을 수 없습니다."));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/service/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/service/CouponService.java
@@ -1,0 +1,105 @@
+package com.loopers.domain.coupone.service;
+
+import com.loopers.domain.coupone.DiscountPolicy;
+import com.loopers.domain.coupone.DiscountPolicyFactory;
+import com.loopers.domain.coupone.dto.CouponCommand;
+import com.loopers.domain.coupone.dto.CouponInfo;
+import com.loopers.domain.coupone.entity.CouponModel;
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import com.loopers.domain.coupone.enums.CouponStatus;
+import com.loopers.domain.coupone.repository.CouponPolicyRepository;
+import com.loopers.domain.coupone.repository.CouponRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.pagenation.PageResult;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final CouponPolicyRepository couponPolicyRepository;
+
+    @Transactional
+    public CouponInfo issueCoupon(CouponCommand.IssueCoupon command) {
+        // 쿠폰 정책을 조회하고 락을 획득
+        CouponPolicyModel couponPolicyModel = couponPolicyRepository.findWithLock(command.couponPolicyId())
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰 정책을 찾을 수 없습니다."));
+        LocalDateTime now = LocalDateTime.now();
+
+        if (couponPolicyModel.getRemainQuantity().getQuantity() <= 0) {
+            throw new CoreException(ErrorType.NOT_FOUND, "쿠폰이 모두 소진되었습니다.");
+        }
+        if (now.isBefore(couponPolicyModel.getCouponPeriod().getStartTime()) || now.isAfter(
+            couponPolicyModel.getCouponPeriod().getEndTime())) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 발급 기간이 아닙니다.");
+        }
+
+        // 쿠폰 수량 감소 (원자적 업데이트)
+        int updated = couponPolicyRepository.decreaseRemainQuantity(command.couponPolicyId());
+        if (updated == 0) {
+            throw new CoreException(ErrorType.NOT_FOUND, "쿠폰이 모두 소진되었습니다.");
+        }
+
+        CouponModel couponModel = CouponModel.of(
+            command.couponPolicyId(),
+            command.userId(),
+            CouponStatus.AVAILABLE,
+            now,
+            couponPolicyModel.getCouponPeriod().getEndTime()
+        );
+
+        CouponModel saved = couponRepository.save(couponModel);
+        return CouponInfo.from(saved);
+    }
+
+    @Transactional
+    public CouponInfo useCoupon(CouponCommand.UseCoupon command) {
+        CouponModel couponModel = couponRepository.findWithLockByIdAndRefUserId(command.couponId(), command.userId())
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰을 찾을 수 없습니다."));
+
+        couponModel.use(command.orderId());
+
+        return CouponInfo.from(couponModel);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResult<CouponInfo> getCoupons(CouponCommand.GetMyCoupons command) {
+        PageResult<CouponModel> pageResult = couponRepository.findUserCoupon(command.userId(), command.page(), command.size());
+        List<CouponInfo> couponInfos = pageResult.content().stream().map(CouponInfo::from).toList();
+        return new PageResult<>(
+            couponInfos,
+            pageResult.paginationInfo()
+        );
+    }
+
+    @Transactional
+    public Long calculateDiscount(Long couponId, Long userId, Long orderAmount) {
+        CouponModel couponModel = couponRepository.findByIdAndUserId(couponId, userId)
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰을 찾을 수 없습니다."));
+
+        if (couponModel.isUsed() || couponModel.isExpired()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용할 수 없는 쿠폰입니다.");
+        }
+
+        CouponPolicyModel policyModel = couponPolicyRepository.find(couponModel.getRefCouponPolicyId())
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰 정책을 찾을 수 없습니다."));
+
+        // 최소 주문 금액 검증
+        if (policyModel.getOrderAmountCondition().getMinimumOrderAmount() != null
+            && orderAmount < policyModel.getOrderAmountCondition().getMinimumOrderAmount()) {
+            throw new CoreException(ErrorType.BAD_REQUEST,
+                "최소 주문 금액(" + policyModel.getOrderAmountCondition().getMinimumOrderAmount() + "원)을 충족하지 않습니다.");
+        }
+
+        // 할인 정책 생성 및 적용
+        DiscountPolicy discountPolicy = DiscountPolicyFactory.createFrom(policyModel);
+        return discountPolicy.calculateDiscount(orderAmount);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/CouponPeriod.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/CouponPeriod.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.coupone.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Embeddable
+public class CouponPeriod {
+
+    @Column(nullable = false)
+    private LocalDateTime startTime; // 발행 시작 시간
+
+    @Column(nullable = false)
+    private LocalDateTime endTime; // 발행 종료 시간
+
+    private CouponPeriod(LocalDateTime startTime, LocalDateTime endTime) {
+        if (startTime == null || endTime == null) {
+            throw new IllegalArgumentException("시작 시간과 종료 시간은 필수입니다.");
+        }
+        if (startTime.isAfter(endTime)) {
+            throw new IllegalArgumentException("시작 시간은 종료 시간보다 이후일 수 없습니다.");
+        }
+
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public static CouponPeriod of(LocalDateTime startTime, LocalDateTime endTime) {
+        return new CouponPeriod(startTime, endTime);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/CouponPolicyName.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/CouponPolicyName.java
@@ -1,0 +1,42 @@
+package com.loopers.domain.coupone.vo;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Embeddable
+public class CouponPolicyName {
+    private static final int MIN_NAME_LENGTH = 2;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    private CouponPolicyName(String name) {
+        checkLength(name);
+        this.name = name;
+    }
+
+    public static CouponPolicyName of(String name) {
+        return new CouponPolicyName(name);
+    }
+
+    protected void checkLength(String name) {
+        if (name == null || name.isEmpty()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 정책명은 필수입니다.");
+        }
+
+        if (name.length() < MIN_NAME_LENGTH) {
+            throw new CoreException(ErrorType.BAD_REQUEST, String.format("쿠폰 정책명은 최소 %d글자 이상 입니다.", MIN_NAME_LENGTH));
+        }
+
+        if (name.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 정책명은 비어있을 수 없습니다.");
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/DiscountValue.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/DiscountValue.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.coupone.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Embeddable
+public class DiscountValue {
+
+    @Column(nullable = false)
+    private BigDecimal discountValue; // 할인 값/률
+
+    private DiscountValue(BigDecimal discountValue) {
+        if (discountValue == null || discountValue.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("할인 값은 0 이상이어야 합니다.");
+        }
+        this.discountValue = discountValue.setScale(2, RoundingMode.HALF_UP); // 소수점 2자리 고정
+    }
+
+    public static DiscountValue of(BigDecimal discountValue) {
+        return new DiscountValue(discountValue);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/ExpirationTime.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/ExpirationTime.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.coupone.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Embeddable
+public class ExpirationTime {
+
+    @Column(nullable = false)
+    private LocalDateTime  expirationTime;
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/OrderAmountCondition.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/OrderAmountCondition.java
@@ -1,0 +1,34 @@
+package com.loopers.domain.coupone.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Embeddable
+public class OrderAmountCondition {
+
+    @Column(nullable = false)
+    private Integer minimumOrderAmount; // 최소 주문 금액
+
+    @Column(nullable = false)
+    private Integer maximumDiscountAmount; // 최대 할인 금액
+
+    private OrderAmountCondition(Integer minimumOrderAmount, Integer maximumDiscountAmount) {
+        if (minimumOrderAmount == null || minimumOrderAmount < 0)
+            throw new IllegalArgumentException("최소 주문 금액은 0 이상이어야 합니다.");
+
+        if (maximumDiscountAmount == null || maximumDiscountAmount < 0)
+            throw new IllegalArgumentException("최대 할인 금액은 0 이상이어야 합니다.");
+
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.maximumDiscountAmount = maximumDiscountAmount;
+    }
+
+    public static OrderAmountCondition of(Integer minimumOrderAmount, Integer maximumDiscountAmount) {
+        return new OrderAmountCondition(minimumOrderAmount, maximumDiscountAmount);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/UsagePeriod.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupone/vo/UsagePeriod.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.coupone.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Embeddable
+public class UsagePeriod {
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt; // 발행 시간
+
+    @Column(name = "expiration_time", nullable = false)
+    private LocalDateTime expirationTime; // 만료 시간
+
+    private UsagePeriod(LocalDateTime issuedAt, LocalDateTime expirationTime) {
+        if (issuedAt == null || expirationTime == null) {
+            throw new IllegalArgumentException("발행 시간과 만료 시간은 필수입니다.");
+        }
+        if (issuedAt.isAfter(expirationTime)) {
+            throw new IllegalArgumentException("발행 시간은 만료 시간보다 이후일 수 없습니다.");
+        }
+
+        this.issuedAt = issuedAt;
+        this.expirationTime = expirationTime;
+    }
+
+    public static UsagePeriod of(LocalDateTime issuedAt, LocalDateTime expirationTime) {
+        return new UsagePeriod(issuedAt, expirationTime);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/inventory/repository/InventoryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/inventory/repository/InventoryRepository.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.inventory.repository;
 
 import com.loopers.domain.inventory.InventoryModel;
+import java.util.List;
 import java.util.Optional;
 
 public interface InventoryRepository {
@@ -8,6 +9,8 @@ public interface InventoryRepository {
     InventoryModel save(InventoryModel inventory);
 
     Optional<InventoryModel> find(Long productSkuId);
+
+    Optional<InventoryModel> findWithLock(Long productSkuId);
 
     Boolean isExists(Long productSkuId);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/inventory/service/InventorySkuValidator.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/inventory/service/InventorySkuValidator.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.inventory.service;
+
+import com.loopers.domain.inventory.InventoryModel;
+import com.loopers.domain.inventory.repository.InventoryRepository;
+import com.loopers.domain.product.dto.sku.ProductSkuCommand.OrderSku;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InventorySkuValidator {
+
+    private final InventoryRepository inventoryRepository;
+
+    public void validateSkuStock(List<OrderSku> skuList){
+        for (OrderSku orderSku : skuList) {
+            // 재고 시스템에서 해당 SKU의 재고 확인
+            InventoryModel sku = inventoryRepository.findWithLock(orderSku.skuId())
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품을 찾을 수 없습니다."));
+            Long availableQuantity = sku.getQuantity().getQuantity();
+            // 주문 수량이 재고보다 많은 경우 예외 발생
+            if (availableQuantity < orderSku.quantity()) {
+                throw new CoreException(ErrorType.BAD_REQUEST,
+                    String.format("상품 SKU(ID: %d)의 재고가 부족합니다. 요청: %d, 가능: %d",
+                        orderSku.skuId(), orderSku.quantity(), availableQuantity));
+            }
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeModel.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,12 +17,15 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Table(name = "likes")
+@Table(name = "likes",
+    uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"ref_user_id", "ref_target_id", "like_type"})
+})
 public class LikeModel extends BaseEntity {
-    @Column(name = "user_id", nullable = false)
+    @Column(name = "ref_user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "target_id", nullable = false)
+    @Column(name = "ref_target_id", nullable = false)
     private Long targetId;
 
     @Enumerated(EnumType.STRING)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/repository/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/repository/LikeRepository.java
@@ -8,11 +8,13 @@ public interface LikeRepository {
 
     LikeModel save(LikeModel like);
 
-    void delete(LikeModel like);
-
     Long count(Long target, LikeType type);
 
     boolean isExists(Long userId, Long target, LikeType type);
 
     Optional<LikeModel> find(Long userId, Long target, LikeType type);
+
+    void deleteWithLock(Long userId, Long targetId, LikeType likeType);
+
+    Optional<LikeModel> findWithLock(Long userId, Long target, LikeType type);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/service/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/service/LikeService.java
@@ -5,7 +5,9 @@ import com.loopers.domain.like.dto.LikeCommand;
 import com.loopers.domain.like.enums.LikeType;
 import com.loopers.domain.like.repository.LikeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -14,19 +16,28 @@ public class LikeService {
 
     private final LikeRepository likeRepository;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = DataIntegrityViolationException.class)
     public void like(LikeCommand.Like command) {
-        LikeModel like = LikeModel.of(command.userId(), command.targetId(), command.likeType());
-        if (likeRepository.isExists(like.getUserId(), like.getTargetId(), like.getLikeType())) {
-            return;
+
+        // 이미 존재하는지 확인
+        if (likeRepository.isExists(command.userId(), command.targetId(), command.likeType())) {
+            return; // 이미 존재하면 아무 작업 없이 리턴
         }
-        likeRepository.save(like);
+
+        try {
+            LikeModel like = LikeModel.of(command.userId(), command.targetId(), command.likeType());
+            likeRepository.save(like);
+        } catch (DataIntegrityViolationException e) {
+            // 동시성 문제로 인한 중복 등록 시도 - 무시
+            // 이 예외는 롤백되지 않음 (noRollbackFor 설정)
+           return;
+        }
+
     }
 
     @Transactional
-    public void unlike(final LikeCommand.Unlike command) {
-        likeRepository.find(command.userId(), command.targetId(), command.likeType())
-            .ifPresent(likeRepository::delete);
+    public void unlike(LikeCommand.Unlike command) {
+        likeRepository.deleteWithLock(command.userId(), command.targetId(), command.likeType());
     }
 
     public Long count(Long targetId, LikeType likeType) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
@@ -64,4 +64,7 @@ public class OrderModel extends BaseEntity {
             .reduce(0L, Long::sum );
     }
 
+    public void completeOrder() {
+        this.status = OrderStatus.ORDER_SUCCESS;
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/dto/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/dto/OrderCommand.java
@@ -7,8 +7,18 @@ public record OrderCommand() {
 
     public record Order(
         Long userId,
-        List<OrderItemModel> orderItemModels
+        List<OrderItem> orderItem
     ) {
-
+        public record OrderItem(
+            Long quantity,
+            Long purchasePrice,
+            Long refProductSkuId
+        ) {
+            public OrderItemModel toOrderItem() {
+                return OrderItemModel.of(quantity, purchasePrice, refProductSkuId);
+            }
+        }
     }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/service/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/service/OrderService.java
@@ -1,10 +1,14 @@
 package com.loopers.domain.order.service;
 
+import com.loopers.domain.order.OrderItemModel;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.dto.OrderCommand;
 import com.loopers.domain.order.dto.OrderInfo;
 import com.loopers.domain.order.enums.OrderStatus;
 import com.loopers.domain.order.repository.OrderRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,12 +21,25 @@ public class OrderService {
 
     @Transactional
     public OrderInfo placeOrder(OrderCommand.Order command) {
+        List<OrderItemModel> orderItemModels = command.orderItem().stream()
+            .map(item ->  OrderItemModel.of(item.quantity(), item.purchasePrice(), item.refProductSkuId()))
+            .toList();
+
         OrderModel orderModel = OrderModel.of(
             command.userId(),
-            command.orderItemModels(),
+            orderItemModels,
             OrderStatus.PENDING);
         OrderModel save = orderRepository.save(orderModel);
         return OrderInfo.from(save);
     }
+
+    @Transactional
+    public OrderInfo completeOrder(Long orderId) {
+        OrderModel orderModel = orderRepository.find(orderId)
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "주문을 찾을 수 없습니다."));
+        orderModel.completeOrder();
+        return OrderInfo.from(orderModel);
+    }
+
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
@@ -2,16 +2,13 @@ package com.loopers.domain.point;
 
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.point.vo.Amount;
-import com.loopers.domain.user.UserModel;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import jakarta.persistence.Version;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,6 +22,9 @@ public class PointModel extends BaseEntity {
     @Column(name = "ref_user_id", nullable = false)
     private Long refUserId;
 
+    @Version
+    Long version;
+
     private PointModel(Long amount, Long refUserId) {
         this.amount = new Amount(amount);
         this.refUserId = refUserId;
@@ -34,4 +34,12 @@ public class PointModel extends BaseEntity {
         return new PointModel(amount, refUserId);
     }
 
+
+    public void charge(final Long amount) {
+        this.amount.charge(amount);
+    }
+
+    public void use(final Long amount) {
+        this.amount.use(amount);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/repository/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/repository/PointRepository.java
@@ -15,6 +15,8 @@ public interface PointRepository {
 
     Optional<PointModel> findByUserId(Long userId);
 
+    Optional<PointModel> findWithLockByUserId(Long userId);
+
     Boolean existsByUserId(Long userId);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/vo/Amount.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/vo/Amount.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Embeddable
 public class Amount {
+
     @Column(name = "amount", nullable = false)
     Long amount;
 
@@ -22,5 +23,21 @@ public class Amount {
             throw new CoreException(ErrorType.BAD_REQUEST, "포인트는 음수일 수 없습니다.");
         }
         this.amount = amount;
+    }
+
+    public void charge(Long amount) {
+        if (amount < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "충전할 금액은 음수일 수 없습니다.");
+        }
+
+        this.amount += amount;
+    }
+
+    public void use(Long amount) {
+        if (this.amount < amount) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "금액이 부족 합니다.");
+        }
+
+        this.amount -= amount;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/sku/ProductSkuCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/sku/ProductSkuCommand.java
@@ -23,4 +23,14 @@ public record ProductSkuCommand() {
 
     }
 
+    public record GetValidSku(
+        List<OrderSku> skuList
+    ) {
+    }
+
+    public record OrderSku(
+        Long skuId, Long quantity
+    ) {
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/sku/ProductSkuInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/sku/ProductSkuInfo.java
@@ -8,6 +8,7 @@ public record ProductSkuInfo(
     Long id,
     String optionType,
     String optionValue,
+    Long price,
     Long additionalPrice,
     Long refProductId,
     SaleStatus saleStatus
@@ -17,6 +18,7 @@ public record ProductSkuInfo(
             productSku.getId(),
             productSku.getOption().getOptionType(),
             productSku.getOption().getOptionType(),
+            productSku.getPrice().getAmount(),
             productSku.getAdditionalPrice().getAmount(),
             productSku.getRefProductId(),
             productSku.getSaleStatus()

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/entity/ProductSkuModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/entity/ProductSkuModel.java
@@ -23,6 +23,10 @@ import lombok.NoArgsConstructor;
 public class ProductSkuModel extends BaseEntity {
 
     @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "price", nullable = false))
+    Money price; // 가격
+
+    @Embedded
     @AttributeOverride(name = "amount", column = @Column(name = "additional_price", nullable = false))
     Money additionalPrice; // 옵션에대한 추가 가격
 
@@ -35,16 +39,17 @@ public class ProductSkuModel extends BaseEntity {
     @Column(name = "ref_product_id", nullable = false)
     private Long refProductId;
 
-    private ProductSkuModel(Long additionalPrice, String optionType, String optionValue, SaleStatus saleStatus,
+    private ProductSkuModel(Long price, Long additionalPrice, String optionType, String optionValue, SaleStatus saleStatus,
         Long refProductId) {
+        this.price = Money.of(price);
         this.additionalPrice = Money.of(additionalPrice);
         this.option = ProductOption.of(optionType, optionValue);
         this.saleStatus = saleStatus;
         this.refProductId = refProductId;
     }
 
-    public static ProductSkuModel of(Long additionalPrice, String optionType, String optionValue
+    public static ProductSkuModel of(Long price,Long additionalPrice, String optionType, String optionValue
         , SaleStatus saleStatus, Long refProductId) {
-        return new ProductSkuModel(additionalPrice, optionType, optionValue, saleStatus, refProductId);
+        return new ProductSkuModel(price, additionalPrice, optionType, optionValue, saleStatus, refProductId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/service/ProductSkuService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/service/ProductSkuService.java
@@ -1,7 +1,11 @@
 package com.loopers.domain.product.service;
 
-import com.loopers.domain.product.dto.sku.ProductSkuCommand.GetProSkus;
+import com.loopers.domain.inventory.InventoryModel;
+import com.loopers.domain.inventory.repository.InventoryRepository;
+import com.loopers.domain.inventory.service.InventorySkuValidator;
+import com.loopers.domain.product.dto.sku.ProductSkuCommand.GetValidSku;
 import com.loopers.domain.product.dto.sku.ProductSkuCommand.GetSku;
+import com.loopers.domain.product.dto.sku.ProductSkuCommand.OrderSku;
 import com.loopers.domain.product.dto.sku.ProductSkuInfo;
 import com.loopers.domain.product.entity.ProductSkuModel;
 import com.loopers.domain.product.repository.ProductSkuRepository;
@@ -16,6 +20,8 @@ import org.springframework.stereotype.Service;
 public class ProductSkuService {
 
     private final ProductSkuRepository productSkuRepository;
+    private final InventorySkuValidator inventorySkuValidator;
+
 
     public ProductSkuInfo get(GetSku command) {
         ProductSkuModel productSkuModel = productSkuRepository.find(command.id())
@@ -23,9 +29,19 @@ public class ProductSkuService {
         return ProductSkuInfo.from(productSkuModel);
     }
 
-    public List<ProductSkuInfo> getSkus(GetProSkus command) {
-        List<ProductSkuModel> productSkuModel = productSkuRepository.findAllById(command.ids());
-        return productSkuModel.stream().map(
+    public List<ProductSkuInfo> getValidSku(GetValidSku command) {
+        // SKU ID 목록 추출
+        List<Long> skuIds = command.skuList().stream()
+            .map(OrderSku::skuId)
+            .toList();
+
+        // SKU 정보 조회
+        List<ProductSkuModel> productSkuModels = productSkuRepository.findAllById(skuIds);
+
+        // 재고 수량 확인
+        inventorySkuValidator.validateSkuStock(command.skuList());
+
+        return productSkuModels.stream().map(
             ProductSkuInfo::from
         ).toList();
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupone.entity.CouponModel;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CouponJpaRepository extends JpaRepository<CouponModel, Long> {
+
+    Long countByRefCouponPolicyId(Long id);
+
+    Optional<CouponModel> findByIdAndRefUserId(Long id, Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM CouponModel c WHERE c.id = :id AND c.refUserId = :userId")
+    Optional<CouponModel> findWithLockByIdAndRefUserId(@Param("id") Long id, @Param("userId") Long userId);
+
+    Page<CouponModel> findByRefUserId(Long userId, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponPolicyJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponPolicyJpaRepository.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CouponPolicyJpaRepository extends JpaRepository<CouponPolicyModel, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cp FROM CouponPolicyModel cp WHERE cp.id = :id")
+    Optional<CouponPolicyModel> findByIdWithLock(@Param("id") Long id);
+
+
+    @Modifying
+    @Query("UPDATE CouponPolicyModel cp "
+        + "SET cp.remainQuantity.quantity = cp.remainQuantity.quantity - 1 "
+        + "WHERE cp.id = :id  AND cp.remainQuantity.quantity > 0 ")
+    int decreaseRemainQuantity(@Param("id") Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponPolicyRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponPolicyRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import com.loopers.domain.coupone.repository.CouponPolicyRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponPolicyRepositoryImpl implements CouponPolicyRepository {
+
+    private final CouponPolicyJpaRepository couponPolicyJpaRepository;
+
+    @Override
+    public CouponPolicyModel save(CouponPolicyModel couponPolicyModel) {
+        return couponPolicyJpaRepository.save(couponPolicyModel);
+    }
+
+    @Override
+    public Optional<CouponPolicyModel> find(Long id) {
+        return couponPolicyJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<CouponPolicyModel> findWithLock(Long id) {
+        return couponPolicyJpaRepository.findByIdWithLock(id);
+    }
+
+    @Override
+    public int decreaseRemainQuantity(Long id) {
+        return couponPolicyJpaRepository.decreaseRemainQuantity(id);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupone.entity.CouponModel;
+import com.loopers.domain.coupone.repository.CouponRepository;
+import com.loopers.support.pagenation.PageResult;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public CouponModel save(CouponModel coupon) {
+        return couponJpaRepository.save(coupon);
+    }
+
+    @Override
+    public Optional<CouponModel> find(Long id) {
+        return couponJpaRepository.findById(id);
+    }
+
+    @Override
+    public Long countByCouponPolicyId(Long id) {
+        return couponJpaRepository.countByRefCouponPolicyId(id);
+    }
+
+    @Override
+    public Optional<CouponModel> findByIdAndUserId(Long id, Long userId) {
+        return couponJpaRepository.findByIdAndRefUserId(id, userId);
+    }
+
+    @Override
+    public Optional<CouponModel> findWithLockByIdAndRefUserId(Long id, Long userId) {
+        return couponJpaRepository.findWithLockByIdAndRefUserId(id, userId);
+    }
+
+
+    @Override
+    public PageResult<CouponModel> findUserCoupon(Long userId, Integer page, Integer size) {
+        Pageable pageable =
+            PageRequest.of(page - 1
+                , size
+            );
+        Page<CouponModel> pageResult = couponJpaRepository.findByRefUserId(userId, pageable);
+        return PageResult.of(pageResult);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/inventory/InventoryJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/inventory/InventoryJpaRepository.java
@@ -1,14 +1,20 @@
 package com.loopers.infrastructure.inventory;
 
 import com.loopers.domain.inventory.InventoryModel;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface InventoryJpaRepository extends JpaRepository<InventoryModel, Long> {
 
     Optional<InventoryModel> findByRefProductSkuId(Long productSkuId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT i FROM InventoryModel i WHERE i.refProductSkuId = :productSkuId")
+    Optional<InventoryModel> findByRefProductSkuIdWithLock(Long productSkuId);
 
     Boolean existsByRefProductSkuId(Long productSkuId);
 
@@ -21,6 +27,7 @@ public interface InventoryJpaRepository extends JpaRepository<InventoryModel, Lo
     @Modifying
     @Query("UPDATE InventoryModel i "
         + "SET i.quantity.quantity = i.quantity.quantity - :quantity "
-        + "WHERE i.refProductSkuId = :productSkuId ")
+        + "WHERE i.refProductSkuId = :productSkuId "
+        + "AND  i.quantity.quantity  >=  :quantity ")
     int decreaseStock(Long productSkuId, Long quantity);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/inventory/InventoryRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/inventory/InventoryRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.loopers.infrastructure.inventory;
 
 import com.loopers.domain.inventory.InventoryModel;
 import com.loopers.domain.inventory.repository.InventoryRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,6 +21,11 @@ public class InventoryRepositoryImpl implements InventoryRepository {
     @Override
     public Optional<InventoryModel> find(Long productSkuId) {
         return inventoryJpaRepository.findByRefProductSkuId(productSkuId);
+    }
+
+    @Override
+    public Optional<InventoryModel> findWithLock(Long productSkuId) {
+        return inventoryJpaRepository.findByRefProductSkuIdWithLock(productSkuId);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -2,12 +2,29 @@ package com.loopers.infrastructure.like;
 
 import com.loopers.domain.like.LikeModel;
 import com.loopers.domain.like.enums.LikeType;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LikeJpaRepository extends JpaRepository<LikeModel, Long> {
 
     Optional<LikeModel> findByUserIdAndTargetIdAndLikeType(Long userId, Long target, LikeType type);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT l FROM LikeModel l WHERE l.userId = :userId AND l.targetId = :targetId AND l.likeType = :likeType")
+    Optional<LikeModel> findWithLockByUserIdAndTargetIdAndLikeType(
+        @Param("userId") Long userId,
+        @Param("targetId") Long targetId,
+        @Param("likeType") LikeType likeType
+    );
+
+    @Modifying
+    @Query("DELETE FROM LikeModel l WHERE l.userId = :userId AND l.targetId = :targetId AND l.likeType = :likeType")
+    void deleteWithLock(@Param("userId") Long userId, @Param("targetId") Long targetId, @Param("likeType") LikeType likeType);
 
     Long countByTargetIdAndLikeType(Long target, LikeType type);
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -19,8 +19,8 @@ public class LikeRepositoryImpl implements LikeRepository {
     }
 
     @Override
-    public void delete(LikeModel like) {
-        likeJpaRepository.deleteById(like.getId());
+    public void deleteWithLock(Long userId,  Long targetId,  LikeType likeType) {
+        likeJpaRepository.deleteWithLock(userId, targetId, likeType);
     }
 
     @Override
@@ -36,5 +36,10 @@ public class LikeRepositoryImpl implements LikeRepository {
     @Override
     public Optional<LikeModel> find(Long userId, Long target, LikeType type) {
         return likeJpaRepository.findByUserIdAndTargetIdAndLikeType(userId, target, type);
+    }
+
+    @Override
+    public Optional<LikeModel> findWithLock(Long userId, Long target, LikeType type) {
+        return likeJpaRepository.findWithLockByUserIdAndTargetIdAndLikeType(userId, target, type);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,13 +1,20 @@
 package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.PointModel;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PointJpaRepository extends JpaRepository<PointModel, Long> {
     Optional<PointModel> findByRefUserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM PointModel p WHERE p.refUserId = :userId")
+    Optional<PointModel> findWithLockByUserId(@Param("userId") Long userId);
 
     @Modifying
     @Query("UPDATE PointModel p "
@@ -18,7 +25,8 @@ public interface PointJpaRepository extends JpaRepository<PointModel, Long> {
     @Modifying
     @Query("UPDATE PointModel p "
         + "SET p.amount.amount = p.amount.amount - :point "
-        + "WHERE p.refUserId = :userId ")
+        + "WHERE p.refUserId = :userId "
+        + "AND p.amount.amount >= :point ")
     int decrease(Long userId, Long point);
 
     @Modifying

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -43,6 +43,11 @@ public class PointRepositoryImpl implements PointRepository {
     }
 
     @Override
+    public Optional<PointModel> findWithLockByUserId(Long userId) {
+        return pointJpaRepository.findWithLockByUserId(userId);
+    }
+
+    @Override
     public Boolean existsByUserId(Long userId) {
         return pointJpaRepository.existsByRefUserId(userId);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponPolicyV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponPolicyV1ApiController.java
@@ -1,0 +1,41 @@
+package com.loopers.interfaces.api.coupon;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.CreateRequest;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.CreateResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.GetCouponPolicyResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.SummaryListResponse;
+import com.loopers.support.pagenation.PageResult;
+import com.loopers.support.pagenation.Pageable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/coupon-policy")
+public class CouponPolicyV1ApiController implements CouponPolicyV1ApiSpec {
+
+
+    @PostMapping()
+    @Override
+    public ApiResponse<CreateResponse> createCouponPolicyRequest(
+        CreateRequest request) {
+        return null;
+    }
+
+    @GetMapping("/{couponId}")
+    @Override
+    public ApiResponse<GetCouponPolicyResponse> getCouponPolicy(Long couponId) {
+        return null;
+    }
+
+    @GetMapping()
+    @Override
+    public ApiResponse<PageResult<SummaryListResponse>> getCouponPolicies(
+         Pageable pageable) {
+        return null;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponPolicyV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponPolicyV1ApiSpec.java
@@ -1,0 +1,37 @@
+package com.loopers.interfaces.api.coupon;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.CreateRequest;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.CreateResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.GetCouponPolicyResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.SummaryListResponse;
+import com.loopers.support.pagenation.PageResult;
+import com.loopers.support.pagenation.Pageable;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Coupon policy V1 API", description = "Coupon policy management API for version 1")
+public interface CouponPolicyV1ApiSpec {
+
+    @Operation(
+        summary = "쿠폰 정책을 생성",
+        description = "새로운 쿠폰 정책을 생성합니다."
+    )
+    ApiResponse<CreateResponse> createCouponPolicyRequest(
+        CreateRequest request
+    );
+
+
+    @Operation(
+        summary = "쿠폰 정책 조회",
+        description = "특정 쿠폰 정책의 상세 정보를 조회합니다."
+    )
+    ApiResponse<GetCouponPolicyResponse> getCouponPolicy(Long couponId);
+
+    @Operation(
+        summary = "쿠폰 정책 목록 조회",
+        description = "쿠폰 정책 목록을 조회합니다."
+    )
+    ApiResponse<PageResult<SummaryListResponse>> getCouponPolicies(Pageable pageable);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponPolicyV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponPolicyV1Dto.java
@@ -1,0 +1,33 @@
+package com.loopers.interfaces.api.coupon;
+
+public record CouponPolicyV1Dto() {
+
+    // 생성 요청
+    public record CreateRequest(
+
+    ) {
+
+    }
+
+    // 생성 응답
+    public record CreateResponse(
+
+    ) {
+
+    }
+
+    // 단건 조회 응답
+    public record GetCouponPolicyResponse(
+
+    ) {
+
+    }
+
+    // 다건 조회 응답
+    public record SummaryListResponse(
+
+    ) {
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/coupon/CouponV1ApiSpec.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.api.coupon;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.CreateRequest;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.CreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Coupon V1 API", description = "Coupon management API for version 1")
+public interface CouponV1ApiSpec {
+
+    @Operation(
+        summary = "쿠폰 정책을 생성",
+        description = "새로운 쿠폰 정책을 생성합니다."
+    )
+    ApiResponse<CreateResponse> createCouponPolicyRequest(
+        CreateRequest request
+    );
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/pagenation/Pageable.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/pagenation/Pageable.java
@@ -8,7 +8,7 @@ public class Pageable {
     private final int size;
 
     public Pageable() {
-        this(1, 10);
+        this(1, 20);
     }
 
     public Pageable(int page, int size) {

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupone/entity/CouponPolicyModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupone/entity/CouponPolicyModelTest.java
@@ -1,0 +1,58 @@
+package com.loopers.domain.coupone.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.loopers.domain.coupone.enums.DiscountType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+
+class CouponPolicyModelTest {
+
+    @DisplayName("쿠폰 모델을 생성할 때, ")
+    @Nested
+    class Create {
+
+        @DisplayName("쿠폰정보가 정상적이면 성공한다.")
+        @Test
+        void given_validParameters_when_creatingCouponPolicyModel_thenCeateSuccessfully() {
+            // Given
+            String name = "Test Coupon";
+            String description = "Test Description";
+            LocalDateTime startTime = LocalDateTime.now();
+            LocalDateTime endTime = LocalDateTime.now().plusDays(10);
+            DiscountType discountType = DiscountType.FIXED_AMOUNT;
+            Long totalQuantity = 100L;
+            Integer minimumOrderAmount = 1000;
+            Integer maximumDiscountAmount = 500;
+            BigDecimal discountValue = BigDecimal.valueOf(50.00);
+            Long remainQuantity = 100L;
+
+            // When
+            CouponPolicyModel couponPolicyModel = CouponPolicyModel.of(name, description, startTime,
+                endTime,
+                discountType, totalQuantity, minimumOrderAmount, maximumDiscountAmount, discountValue,
+                remainQuantity);
+
+            // Then
+            assertAll(
+                () -> assertNotNull(couponPolicyModel),
+                () -> assertEquals(name, couponPolicyModel.getName().getName()),
+                () -> assertEquals(description, couponPolicyModel.getDescription()),
+                () -> assertEquals(discountType, couponPolicyModel.getDiscountType()),
+                () -> assertEquals(totalQuantity, couponPolicyModel.getTotalQuantity().getQuantity()),
+                () -> assertEquals(remainQuantity, couponPolicyModel.getRemainQuantity().getQuantity()),
+                () -> assertEquals(startTime, couponPolicyModel.getCouponPeriod().getStartTime()),
+                () -> assertEquals(endTime, couponPolicyModel.getCouponPeriod().getEndTime()),
+                () -> assertEquals(minimumOrderAmount, couponPolicyModel.getOrderAmountCondition().getMinimumOrderAmount()),
+                () -> assertEquals(maximumDiscountAmount, couponPolicyModel.getOrderAmountCondition().getMaximumDiscountAmount()),
+                () -> assertThat(couponPolicyModel.getDiscountValue().getDiscountValue()).isEqualByComparingTo(discountValue)
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupone/service/CouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupone/service/CouponServiceTest.java
@@ -130,7 +130,7 @@ class CouponServiceTest {
         @Test
         void given_couponPolicy_when_createCoupon_then_createCoupon() throws InterruptedException {
 
-            Long testQuantity = 500L;
+            Long testQuantity = 100L;
 
             CouponPolicyModel couponPolicyModel = CouponPolicyModel.of(
                 "테스트 쿠폰",

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupone/service/CouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupone/service/CouponServiceTest.java
@@ -1,0 +1,345 @@
+package com.loopers.domain.coupone.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.loopers.domain.coupone.dto.CouponCommand;
+import com.loopers.domain.coupone.dto.CouponInfo;
+import com.loopers.domain.coupone.entity.CouponModel;
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import com.loopers.domain.coupone.enums.CouponStatus;
+import com.loopers.domain.coupone.enums.DiscountType;
+import com.loopers.domain.coupone.repository.CouponPolicyRepository;
+import com.loopers.domain.coupone.repository.CouponRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.pagenation.PageResult;
+import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CouponServiceTest {
+
+    @Autowired
+    private CouponService sut;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Autowired
+    CouponPolicyRepository couponPolicyRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("쿠폰 발급할 때, ")
+    @Nested
+    class IssueCoupon {
+
+        @DisplayName("[fail] - 쿠폰 정책이 없을 때 예외 발생")
+        @Test
+        void given_noCouponPolicy_when_issueCoupon_then_throwNotFoundError() {
+            // Given
+            Long invalidPolicyId = -1L;
+            Long userId = 1L;
+            CouponCommand.IssueCoupon command = new CouponCommand.IssueCoupon(invalidPolicyId, userId);
+
+            // When
+            CoreException actual = assertThrows(CoreException.class, () -> sut.issueCoupon(command));
+
+            // Then
+            assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(new CoreException(ErrorType.NOT_FOUND, "쿠폰 정책을 찾을 수 없습니다."));
+        }
+
+        @DisplayName("[fail] - 쿠폰 발급 기간 외에 발급시도하면 예외 발생")
+        @Test
+        void given_outOfPeriod_when_issueCoupon_then_throwBadRequestError() {
+            // Given
+            CouponPolicyModel couponPolicyModel = CouponPolicyModel.of(
+                "만료된 쿠폰",
+                "쿠폰 설명",
+                LocalDateTime.now().minusDays(10),
+                LocalDateTime.now().minusDays(5),
+                DiscountType.FIXED_AMOUNT,
+                100L,
+                0,
+                0,
+                new BigDecimal("100"),
+                100L
+            );
+            CouponPolicyModel savedPolicyModel = couponPolicyRepository.save(couponPolicyModel);
+            Long policyId = savedPolicyModel.getId();
+            Long userId = 1L;
+            CouponCommand.IssueCoupon command = new CouponCommand.IssueCoupon(policyId, userId);
+
+            // When
+            CoreException actual = assertThrows(CoreException.class, () -> sut.issueCoupon(command));
+
+            // Then
+            assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "쿠폰 발급 기간이 아닙니다."));
+        }
+
+        @DisplayName("[fail] - 쿠폰이 모두 소진되면 예외 발생")
+        @Test
+        void given_noRemainingCoupons_when_issueCoupon_then_throwNotFoundError() {
+            // Given
+            CouponPolicyModel couponPolicyModel = CouponPolicyModel.of(
+                "소진된 쿠폰",
+                "쿠폰 설명",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(5),
+                DiscountType.FIXED_AMOUNT,
+                0L, // 잔여 수량 0
+                0,
+                0,
+                new BigDecimal("100"),
+                0L
+            );
+            CouponPolicyModel savedPolicyModel = couponPolicyRepository.save(couponPolicyModel);
+            Long policyId = savedPolicyModel.getId();
+            Long userId = 1L;
+            CouponCommand.IssueCoupon command = new CouponCommand.IssueCoupon(policyId, userId);
+
+            // When
+            CoreException actual = assertThrows(CoreException.class, () -> sut.issueCoupon(command));
+
+            // Then
+            assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(new CoreException(ErrorType.NOT_FOUND, "쿠폰이 모두 소진되었습니다."));
+        }
+
+        @DisplayName("[happy] - 쿠폰 정책이 주어지면, 쿠폰을 발급한다.")
+        @Test
+        void given_couponPolicy_when_createCoupon_then_createCoupon() throws InterruptedException {
+
+            Long testQuantity = 500L;
+
+            CouponPolicyModel couponPolicyModel = CouponPolicyModel.of(
+                "테스트 쿠폰",
+                "테스트 쿠폰 설명",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(10),
+                DiscountType.FIXED_AMOUNT,
+                testQuantity, // 총 testQuantity개의 쿠폰만 발급 가능
+                0,
+                0,
+                new BigDecimal("100"),
+                testQuantity// 초기 잔여 수량 testQuantity개
+            );
+
+            CouponPolicyModel savedCouponPolicyModel = couponPolicyRepository.save(couponPolicyModel);
+            Long couponPolicyId = savedCouponPolicyModel.getId();
+
+            int numberOfThreads = (int) (testQuantity * 2);// testQuantity*2명의 사용자가 동시에 요청
+            ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+            CountDownLatch latch = new CountDownLatch(numberOfThreads);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // When
+            for (int i = 0; i < numberOfThreads; i++) {
+                final Long userId = (long) (i + 1);
+                executorService.submit(() -> {
+                    try {
+                        CouponCommand.IssueCoupon command = new CouponCommand.IssueCoupon(couponPolicyId, userId);
+                        sut.issueCoupon(command);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            // 모든 스레드가 작업을 마칠 때까지 대기
+            latch.await();
+            executorService.shutdown();
+
+            // Then
+            assertEquals(numberOfThreads - testQuantity, failCount.get()); // numberOfThreads - testQuantity 개의 요청은 실패
+            assertEquals(testQuantity, successCount.get()); // testQuantity 개의 쿠폰만 성공적으로 발급
+
+            // 데이터베이스에서 실제 발급된 쿠폰 수 확인
+            long actualIssuedCount = couponRepository.countByCouponPolicyId(couponPolicyId);
+            assertEquals(testQuantity, actualIssuedCount);
+
+            // 쿠폰 정책의 잔여 수량이 0인지 확인
+            CouponPolicyModel updatedPolicy = couponPolicyRepository.find(couponPolicyId).orElseThrow();
+            assertEquals(0L, updatedPolicy.getRemainQuantity().getQuantity());
+        }
+
+    }
+
+
+    @DisplayName("쿠폰 사용할 때, ")
+    @Nested
+    class UseCoupon {
+
+        private static final Long TEST_USER_ID = 1L;
+        private static final Long TEST_COUPON_ID = 1L;
+        private static final Long TEST_ORDER_ID = 1L;
+
+        @DisplayName("[happy] - 정상적으로 쿠폰 발급후, 쿠폰사용 성공한다.")
+        @Test
+        void when_issueCoupon_then_useCoupon() {
+            // Given
+            CouponPolicyModel couponPolicyModel = CouponPolicyModel.of(
+                "테스트 쿠폰",
+                "테스트 쿠폰 설명",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(10),
+                DiscountType.FIXED_AMOUNT,
+                100L,
+                0,
+                0,
+                new BigDecimal("100"),
+                100L
+            );
+            CouponPolicyModel savedCouponPolicyModel = couponPolicyRepository.save(couponPolicyModel);
+            Long couponPolicyId = savedCouponPolicyModel.getId();
+
+            CouponCommand.IssueCoupon issueCoupon = new CouponCommand.IssueCoupon(couponPolicyId, TEST_USER_ID);
+            sut.issueCoupon(issueCoupon);
+            CouponCommand.UseCoupon useCoupon = new CouponCommand.UseCoupon(couponPolicyId, TEST_ORDER_ID, TEST_USER_ID);
+
+            // When
+            CouponInfo actual = sut.useCoupon(useCoupon);
+
+            // Then
+            assertAll(
+                () -> assertThat(actual.id()).isEqualTo(couponPolicyId),
+                () -> assertThat(actual.orderId()).isEqualTo(TEST_ORDER_ID),
+                () -> assertThat(actual.couponStatus()).isEqualTo(CouponStatus.USED)
+            )
+            ;
+        }
+
+        @DisplayName("[fail] - 쿠폰이 존재하지 않으면 NOT FOUND 예외 발생")
+        @Test
+        void given_nonExistingCoupon_when_useCoupon_then_throwNotFoundError() {
+            // Given
+            // When
+            CouponCommand.UseCoupon useCoupon = new CouponCommand.UseCoupon(TEST_COUPON_ID, TEST_ORDER_ID, TEST_USER_ID);
+            // Then
+            CoreException actual = assertThrows(CoreException.class, () -> {
+                sut.useCoupon(useCoupon);
+            });
+            assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(new CoreException(ErrorType.NOT_FOUND, "쿠폰을 찾을 수 없습니다."));
+        }
+
+        @DisplayName("[fail] - 이미 사용한 쿠폰은 다시 사용할 수 없다")
+        @Test
+        void given_usedCoupon_when_usedCoupon_then_throwBadRequestError() {
+            // Given
+            // 쿠폰 정책 생성
+            CouponPolicyModel couponPolicyModel = CouponPolicyModel.of(
+                "테스트 쿠폰",
+                "테스트 쿠폰 설명",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(10),
+                DiscountType.FIXED_AMOUNT,
+                100L,
+                0,
+                0,
+                new BigDecimal("100"),
+                100L
+            );
+            CouponPolicyModel savedCouponPolicyModel = couponPolicyRepository.save(couponPolicyModel);
+            Long couponPolicyId = savedCouponPolicyModel.getId();
+
+            // 쿠폰 발급
+            CouponCommand.IssueCoupon issueCoupon = new CouponCommand.IssueCoupon(couponPolicyId, TEST_USER_ID);
+            CouponInfo issuedCoupon = sut.issueCoupon(issueCoupon);
+            Long couponId = issuedCoupon.id();
+
+            // 쿠폰 첫 번째 사용 (성공)
+            CouponCommand.UseCoupon firstUseCoupon = new CouponCommand.UseCoupon(couponId, TEST_ORDER_ID, TEST_USER_ID);
+            sut.useCoupon(firstUseCoupon);
+
+            // When & Then
+            // 쿠폰 두 번째 사용 (실패)
+            CouponCommand.UseCoupon secondUseCoupon = new CouponCommand.UseCoupon(couponId, TEST_ORDER_ID + 1, TEST_USER_ID);
+
+            CoreException actual = assertThrows(CoreException.class, () -> {
+                sut.useCoupon(secondUseCoupon);
+            });
+
+            assertThat(actual).usingRecursiveComparison()
+                .isEqualTo(new CoreException(ErrorType.BAD_REQUEST, "이미 사용한 쿠폰입니다."));
+        }
+    }
+
+    @DisplayName("쿠폰 조회할 때, ")
+    @Nested
+    class GetCoupons {
+        private static final Long TEST_USER_ID = 1000L;
+        private static final int DEFAULT_PAGE = 1;
+        private static final int DEFAULT_PAGE_SIZE = 10;
+
+        @DisplayName("[happy] - 정상적으로 쿠폰 발급후, 회원 쿠폰조회 성공한다.")
+        @Test
+        void when_issueCoupons_then_SearchSuccess() {
+            // Given
+            CouponPolicyModel couponPolicy = createTestCouponPolicy();
+            CouponPolicyModel savedCouponPolicy = couponPolicyRepository.save(couponPolicy);
+
+            CouponCommand.IssueCoupon issueCouponCommand = new CouponCommand.IssueCoupon(
+                savedCouponPolicy.getId(),
+                TEST_USER_ID
+            );
+            CouponInfo issuedCoupon = sut.issueCoupon(issueCouponCommand);
+
+            // When
+            CouponCommand.GetMyCoupons getMyCouponsCommand = new CouponCommand.GetMyCoupons(
+                DEFAULT_PAGE,
+                DEFAULT_PAGE_SIZE,
+                TEST_USER_ID
+            );
+            PageResult<CouponInfo> couponsResult = sut.getCoupons(getMyCouponsCommand);
+
+            // Then
+            assertAll(
+                () -> assertThat(couponsResult.content()).hasSize(1),
+                () -> assertThat(couponsResult.content().get(0).id()).isEqualTo(issuedCoupon.id()),
+                () -> assertThat(couponsResult.content().get(0).refUserId()).isEqualTo(TEST_USER_ID)
+            );
+        }
+    }
+
+    private CouponPolicyModel createTestCouponPolicy() {
+        return CouponPolicyModel.of(
+            "테스트 쿠폰",
+            "테스트 쿠폰 설명",
+            LocalDateTime.now().minusDays(1),
+            LocalDateTime.now().plusDays(10),
+            DiscountType.FIXED_AMOUNT,
+            100L,
+            0,
+            0,
+            new BigDecimal("100"),
+            100L
+        );
+    }
+
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/inventory/InventoryModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/inventory/InventoryModelTest.java
@@ -21,7 +21,7 @@ class InventoryModelTest {
         })
         void given_invalidQuantity_when_createInventory_then_throwCoreException(Long invalidQuantity) {
             // given
-            ProductSkuModel productSkuModel = ProductSkuModel.of(0L, "색상", "RED"
+            ProductSkuModel productSkuModel = ProductSkuModel.of(0L,0L, "색상", "RED"
                 , SaleStatus.ON_SALE, null);
             Long refProductId = productSkuModel.getRefProductId();
             // when

--- a/apps/commerce-api/src/test/java/com/loopers/domain/inventory/service/InventoryIntegrationServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/inventory/service/InventoryIntegrationServiceTest.java
@@ -1,0 +1,90 @@
+package com.loopers.domain.inventory.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.loopers.domain.inventory.InventoryModel;
+import com.loopers.domain.inventory.dto.InventoryCommand;
+import com.loopers.domain.inventory.dto.InventoryCommand.GetInventory;
+import com.loopers.domain.inventory.repository.InventoryRepository;
+import com.loopers.domain.point.repository.PointRepository;
+import com.loopers.domain.product.entity.ProductSkuModel;
+import com.loopers.domain.product.enums.SaleStatus;
+import com.loopers.domain.product.repository.ProductSkuRepository;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class InventoryIntegrationServiceTest {
+
+
+    @Autowired
+    private InventoryService sut;
+    @Autowired
+    private ProductSkuRepository productSkuRepository;
+    @Autowired
+    private InventoryRepository inventoryRepository;
+    @Autowired
+    private PointRepository pointRepository;
+
+
+    @DisplayName("재고 감소시킬때, ")
+    @Nested
+    class Decrease {
+        private static final Long TEST_STOCK_SIZE = 50L;
+        @DisplayName("동시에 재고 차감 성공한다.")
+        @Test
+        void given_concurrentRequests_when_decreaseStock_then_stockDecreasedCorrectly() throws InterruptedException {
+            // Given
+            // 상품 및 재고 생성
+            ProductSkuModel productSkuModel = ProductSkuModel.of(0L,0L, "색상", "RED"
+                , SaleStatus.ON_SALE, 1L);
+            ProductSkuModel productSku = productSkuRepository.save(productSkuModel);
+            inventoryRepository.save(InventoryModel.of(TEST_STOCK_SIZE, productSku.getId()));
+
+            int numberOfThreads = 100; // 100개의 동시 요청
+            long requestQuantity = 1L; // 각 요청당 1개씩 차감
+
+
+            ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+            CountDownLatch latch = new CountDownLatch(numberOfThreads);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // When
+            for (int i = 0; i < numberOfThreads; i++) {
+                executorService.submit(() -> {
+                    try {
+                        InventoryCommand.DecreaseStock command = new InventoryCommand.DecreaseStock (productSku.getId(), requestQuantity);
+
+                        sut.decrease(command);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            // 모든 스레드가 작업을 마칠 때까지 대기
+            latch.await();
+            executorService.shutdown();
+
+            // Then
+            assertEquals(TEST_STOCK_SIZE, successCount.get());
+            assertEquals(50, failCount.get());
+
+            InventoryModel inventory = sut.getInventory(new GetInventory(productSku.getId()));
+            int expectedTotalDecreased = (int)(successCount.get() * requestQuantity); // 예상 총 차감량
+            // 재고가 정확히 차감되었는지 확인
+            assertEquals(TEST_STOCK_SIZE - expectedTotalDecreased, inventory.getQuantity().getQuantity());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/service/LikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/service/LikeServiceIntegrationTest.java
@@ -8,12 +8,17 @@ import com.loopers.domain.like.dto.LikeCommand;
 import com.loopers.domain.like.enums.LikeType;
 import com.loopers.domain.like.repository.LikeRepository;
 import com.loopers.utils.DatabaseCleanUp;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.UnexpectedRollbackException;
 
 @SpringBootTest
 public class LikeServiceIntegrationTest {
@@ -31,20 +36,229 @@ public class LikeServiceIntegrationTest {
     }
 
 
+    @DisplayName("동시에 좋아요를 요청할 때, ")
+    @Nested
+    class ConcurrencyLike {
+
+        @DisplayName("[happy] - 여러 사용자가 동시에 같은 상품에 좋아요를 요청하면 모두 성공한다.")
+        @Test
+        void when_multipleConcurrentLikeRequest_then_allRequestsSucceed() throws InterruptedException {
+            // Given
+            Long targetId = 1L;
+            LikeType likeType = LikeType.PRODUCT;
+            int numberOfThreads = 100; // 동시에 요청할 사용자 수
+            ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+            CountDownLatch latch = new CountDownLatch(numberOfThreads);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // When
+            for (int i = 0; i < numberOfThreads; i++) {
+                final Long userId = (long) (i + 1); // 각 스레드마다 다른 사용자 ID 사용
+                executorService.submit(() -> {
+                    try {
+                        LikeCommand.Like command = new LikeCommand.Like(userId, targetId, likeType);
+                        sut.like(command);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            // 모든 스레드가 작업을 마칠 때까지 대기
+            latch.await();
+            executorService.shutdown();
+
+            // Then
+            // 데이터베이스에서 실제 좋아요 수 확인
+            long actualLikeCount = likeRepository.count(targetId, likeType);
+
+            // 검증
+            assertAll(
+                () -> assertThat(successCount.get()).isEqualTo(numberOfThreads),
+                () -> assertThat(failCount.get()).isEqualTo(0L),
+                () -> assertThat(actualLikeCount).isEqualTo(numberOfThreads)
+            );
+        }
+
+
+        @DisplayName("[happy] - 한 사용자가 동시에 같은 상품에 좋아요를 요청하더라도 멱등성을 지키며 성공한다.")
+        @Test
+        void when_singleUserConcurrentLikeRequests_then_registerOnce() throws InterruptedException {
+            // Given
+            Long userId = 1L;  // 단일 사용자
+            Long targetId = 1L;
+            LikeType likeType = LikeType.PRODUCT;
+            int numberOfThreads = 100; // 동시에 요청할 횟수
+            ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+            CountDownLatch latch = new CountDownLatch(numberOfThreads);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // When
+            for (int i = 0; i < numberOfThreads; i++) {
+                executorService.submit(() -> {
+                    try {
+                        LikeCommand.Like command = new LikeCommand.Like(userId, targetId, likeType);
+                        sut.like(command);
+                        successCount.incrementAndGet();
+                    } catch (UnexpectedRollbackException e) {
+                        // 내부 트랜잭션이 rollback-only 상태로 마킹되어 발생한 예외
+                        // 이 경우에도 멱등성을 보장하기 때문에 실패로 보지 않음
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            // 모든 스레드가 작업을 마칠 때까지 대기
+            latch.await();
+            executorService.shutdown();
+
+            // Then
+            // 데이터베이스에서 실제 좋아요 수 확인 (전체 좋아요 수)
+            long totalLikeCount = likeRepository.count(targetId, likeType);
+
+            // 해당 사용자의 좋아요 수 확인 (1개여야 함)
+            boolean userLikeExists = likeRepository.isExists(userId, targetId, likeType);
+
+            // 검증
+            assertAll(
+                () -> assertThat(successCount.get()).isEqualTo(numberOfThreads), // 모든 요청이 예외 없이 처리됨
+                () -> assertThat(failCount.get()).isEqualTo(0L), // 예외가 발생하지 않음
+                () -> assertThat(totalLikeCount).isEqualTo(1), // 총 좋아요 수는 1개
+                () -> assertThat(userLikeExists).isTrue() // 사용자 좋아요가 존재해야 함
+            );
+
+        }
+    }
+
+    @DisplayName("동시에 좋아요 취소를 요청할 때, ")
+    @Nested
+    class ConcurrencyUnlike {
+
+        @DisplayName("[happy] - 여러 사용자가 동시에 같은 상품에 좋아요 취소를 요청하면 모두 성공한다.")
+        @Test
+        void when_multipleConcurrentUnlikeRequest_then_allRequestsSucceed() throws InterruptedException {
+            // Given
+            Long targetId = 1L;
+            LikeType likeType = LikeType.PRODUCT;
+            int numberOfThreads = 10; // 동시에 요청할 사용자 수
+
+            // 좋아요 등록
+            for (int i = 0; i < numberOfThreads; i++) {
+                Long userId = (long) (i + 1);
+                LikeModel likeModel = LikeModel.of(userId, targetId, likeType);
+                likeRepository.save(likeModel);
+            }
+
+            ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+            CountDownLatch latch = new CountDownLatch(numberOfThreads);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // When
+            for (int i = 0; i < numberOfThreads; i++) {
+                final Long userId = (long) (i + 1); // 각 스레드마다 다른 사용자 ID 사용
+                executorService.submit(() -> {
+                    try {
+                        LikeCommand.Unlike command = new LikeCommand.Unlike(userId, targetId, likeType);
+                        sut.unlike(command);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            // 모든 스레드가 작업을 마칠 때까지 대기
+            latch.await();
+            executorService.shutdown();
+
+            // Then
+            // 데이터베이스에서 실제 좋아요 수 확인
+            long actualLikeCount = likeRepository.count(targetId, likeType);
+
+            assertAll(
+                () -> assertThat(successCount.get()).isEqualTo(numberOfThreads),
+                () -> assertThat(failCount.get()).isEqualTo(0L),
+                () -> assertThat(actualLikeCount).isEqualTo(0) // 모든 좋아요가 취소되어야 함
+            );
+        }
+
+        @DisplayName("[happy] - 한 사용자가 동시에 같은 상품에 좋아요 취소를 요청하더라도 멱등성을 지키며 성공한다.")
+        @Test
+        void when_singleUserConcurrentUnlikeRequests_then_removeOnce() throws InterruptedException {
+            // Given
+            Long userId = 1L;  // 단일 사용자
+            Long targetId = 1L;
+            LikeType likeType = LikeType.PRODUCT;
+
+            // 좋아요 등록
+            LikeModel likeModel = LikeModel.of(userId, targetId, likeType);
+            likeRepository.save(likeModel);
+
+            int numberOfThreads = 10; // 동시에 요청할 횟수
+            ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+            CountDownLatch latch = new CountDownLatch(numberOfThreads);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // When
+            for (int i = 0; i < numberOfThreads; i++) {
+                executorService.submit(() -> {
+                    try {
+                        LikeCommand.Unlike command = new LikeCommand.Unlike(userId, targetId, likeType);
+                        sut.unlike(command);
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            // 모든 스레드가 작업을 마칠 때까지 대기
+            latch.await();
+            executorService.shutdown();
+
+            // Then
+            // 해당 사용자의 좋아요가 취소되었는지 확인
+            boolean userLikeExists = likeRepository.isExists(userId, targetId, likeType);
+
+            assertAll(
+                () -> assertThat(successCount.get()).isEqualTo(numberOfThreads), // 모든 요청이 예외 없이 처리됨
+                () -> assertThat(failCount.get()).isEqualTo(0L), // 예외가 발생하지 않음
+                () -> assertThat(userLikeExists).isFalse() // 사용자 좋아요가 취소되어야 함
+            );
+        }
+    }
+
+
     @DisplayName("좋아요를 등록할 때, ")
     @Nested
     class Like {
+
         @DisplayName("좋아요하지 않은 상태면, 좋아요 등록한다.")
         @Test
         void when_userHasNotLikedTarget_then_registerLike() {
-            LikeCommand.Like command=new LikeCommand.Like(1L, 1L, LikeType.PRODUCT);
+            LikeCommand.Like command = new LikeCommand.Like(1L, 1L, LikeType.PRODUCT);
             boolean beforeIsExist = likeRepository.isExists(command.userId(), command.targetId(), command.likeType());
             sut.like(command);
             boolean afterIsExist = likeRepository.isExists(command.userId(), command.targetId(), command.likeType());
 
             assertAll(
-                    () -> assertThat(beforeIsExist).isFalse(),
-                    () -> assertThat(afterIsExist).isTrue()
+                () -> assertThat(beforeIsExist).isFalse(),
+                () -> assertThat(afterIsExist).isTrue()
             );
         }
 
@@ -58,8 +272,8 @@ public class LikeServiceIntegrationTest {
             sut.like(command);
             boolean afterIsExist = likeRepository.isExists(command.userId(), command.targetId(), command.likeType());
             assertAll(
-                    () -> assertThat(beforeIsExist).isTrue(),
-                    () -> assertThat(afterIsExist).isTrue()
+                () -> assertThat(beforeIsExist).isTrue(),
+                () -> assertThat(afterIsExist).isTrue()
             );
         }
     }
@@ -67,6 +281,7 @@ public class LikeServiceIntegrationTest {
     @DisplayName("좋아요를 취소할 때, ")
     @Nested
     class UnLike {
+
         @DisplayName("좋아요한 상태면, 좋아요 취소한다.")
         @Test
         void when_userHasLikedTarget_then_registerLike() {
@@ -78,8 +293,8 @@ public class LikeServiceIntegrationTest {
             boolean afterIsExist = likeRepository.isExists(command.userId(), command.targetId(), command.likeType());
 
             assertAll(
-                    () -> assertThat(beforeIsExist).isTrue(),
-                    () -> assertThat(afterIsExist).isFalse()
+                () -> assertThat(beforeIsExist).isTrue(),
+                () -> assertThat(afterIsExist).isFalse()
             );
         }
 
@@ -92,8 +307,8 @@ public class LikeServiceIntegrationTest {
             boolean afterIsExist = likeRepository.isExists(command.userId(), command.targetId(), command.likeType());
 
             assertAll(
-                    () -> assertThat(beforeIsExist).isFalse(),
-                    () -> assertThat(afterIsExist).isFalse()
+                () -> assertThat(beforeIsExist).isFalse(),
+                () -> assertThat(afterIsExist).isFalse()
             );
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderConcurrencyTest.java
@@ -1,0 +1,298 @@
+package com.loopers.domain.order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.loopers.application.order.OrderFacade;
+import com.loopers.application.order.dto.OrderCriteria;
+import com.loopers.application.order.dto.OrderResult;
+import com.loopers.domain.coupone.dto.CouponCommand;
+import com.loopers.domain.coupone.dto.CouponInfo;
+import com.loopers.domain.coupone.entity.CouponModel;
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import com.loopers.domain.coupone.enums.CouponStatus;
+import com.loopers.domain.coupone.enums.DiscountType;
+import com.loopers.domain.coupone.repository.CouponPolicyRepository;
+import com.loopers.domain.coupone.repository.CouponRepository;
+import com.loopers.domain.coupone.service.CouponService;
+import com.loopers.domain.inventory.InventoryModel;
+import com.loopers.domain.inventory.repository.InventoryRepository;
+import com.loopers.domain.inventory.service.InventoryService;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.repository.OrderRepository;
+import com.loopers.domain.payment.repository.PaymentRepository;
+import com.loopers.domain.point.PointModel;
+import com.loopers.domain.point.repository.PointRepository;
+import com.loopers.domain.point.service.PointService;
+import com.loopers.domain.point.service.dto.PointCommand;
+import com.loopers.domain.product.entity.ProductSkuModel;
+import com.loopers.domain.product.enums.SaleStatus;
+import com.loopers.domain.product.repository.ProductSkuRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SpringBootTest
+public class OrderConcurrencyTest {
+
+    @Autowired
+    private OrderFacade orderFacade;
+
+    @Autowired
+    private ProductSkuRepository productSkuRepository;
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponPolicyRepository couponPolicyRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private static final Long USER_ID = 1L;
+    private static final Long INITIAL_POINT = 1000000L;
+    private static final Long PRODUCT_PRICE = 10000L;
+    private static final Long INITIAL_INVENTORY = 100L;
+
+    private ProductSkuModel productSku;
+    private CouponInfo coupon;
+    private Long couponId;
+
+    @BeforeEach
+    void setUp() {
+        // 상품 생성
+        productSku = ProductSkuModel.of(PRODUCT_PRICE, 0L, "색상", "RED", SaleStatus.ON_SALE, 1L);
+        productSku = productSkuRepository.save(productSku);
+
+        // 재고 생성
+        InventoryModel inventory = InventoryModel.of(INITIAL_INVENTORY, productSku.getId());
+        inventoryRepository.save(inventory);
+
+        // 포인트 생성
+        PointModel pointModel = PointModel.of(INITIAL_POINT, USER_ID);
+        pointRepository.save(pointModel);
+
+        // 쿠폰 정책 생성
+        CouponPolicyModel couponPolicy = CouponPolicyModel.of(
+            "테스트 쿠폰",
+            "테스트용 할인 쿠폰",
+            LocalDateTime.now().minusDays(1),
+            LocalDateTime.now().plusDays(30),
+            DiscountType.FIXED_AMOUNT,
+            10L, // 총 10개의 쿠폰
+            0,
+            5000, // 최대 5000원 할인
+            new BigDecimal("5000"), // 5000원 할인
+            10L // 초기 10개
+        );
+        couponPolicy = couponPolicyRepository.save(couponPolicy);
+
+        // 쿠폰 발급
+        coupon = couponService.issueCoupon(new CouponCommand.IssueCoupon(couponPolicy.getId(), USER_ID));
+        couponId = coupon.id();
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다")
+    @Test
+    void concurrentOrdersWithSameCoupon() throws Exception {
+        // Given
+        final int numOfOrders = 5; // 동시에 5개 주문 시도
+        ExecutorService executorService = Executors.newFixedThreadPool(numOfOrders);
+        CountDownLatch latch = new CountDownLatch(numOfOrders);
+        List<Future<OrderResult>> futures = new ArrayList<>();
+
+        // When
+        for (int i = 0; i < numOfOrders; i++) {
+            Future<OrderResult> future = executorService.submit(() -> {
+                try {
+                    OrderCriteria.Order orderCriteria = new OrderCriteria.Order(
+                        USER_ID,
+                        List.of(new OrderCriteria.Order.OrderItem(productSku.getId(), 1L)),
+                        couponId
+                    );
+                    return orderFacade.order(orderCriteria);
+                } finally {
+                    latch.countDown();
+                }
+            });
+            futures.add(future);
+        }
+
+        latch.await(); // 모든 스레드가 완료될 때까지 대기
+        executorService.shutdown();
+
+        // Then
+        // 성공한 주문 확인
+        List<OrderResult> successfulOrders = new ArrayList<>();
+        for (Future<OrderResult> future : futures) {
+            try {
+                OrderResult result = future.get();
+                if (result != null) {
+                    successfulOrders.add(result);
+                }
+            } catch (Exception e) {
+                // 예외가 발생한 요청은 무시
+            }
+        }
+
+        // 쿠폰 상태 확인
+        CouponModel usedCoupon = couponRepository.find(couponId)
+            .orElseThrow(() -> new RuntimeException("쿠폰을 찾을 수 없습니다"));
+
+        // 쿠폰이 정확히 한 번만 사용되었는지 확인
+        assertAll(
+            () -> assertThat(usedCoupon.getCouponStatus()).isEqualTo(CouponStatus.USED),
+            () -> assertThat(usedCoupon.getOrderId()).isNotNull(),
+            () -> assertThat(successfulOrders.size()).isGreaterThanOrEqualTo(1),
+            // 성공한 주문 중 하나만 쿠폰을 사용했는지 확인
+            () -> assertThat(successfulOrders.stream()
+                .filter(order -> order.id().equals(usedCoupon.getOrderId()))
+                .count()).isEqualTo(1)
+        );
+    }
+
+    @DisplayName("동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다")
+    @Test
+    void concurrentOrdersWithSameUser() throws Exception {
+        // Given
+        final int numOfOrders = 10; // 동시에 10개 주문 시도
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numOfOrders);
+        CountDownLatch latch = new CountDownLatch(numOfOrders);
+        List<Future<OrderResult>> futures = new ArrayList<>();
+
+        // When
+        for (int i = 0; i < numOfOrders; i++) {
+            Future<OrderResult> future = executorService.submit(() -> {
+                try {
+                    OrderCriteria.Order orderCriteria = new OrderCriteria.Order(
+                        USER_ID,
+                        List.of(new OrderCriteria.Order.OrderItem(productSku.getId(), 1L)),
+                        null
+                    );
+                    return orderFacade.order(orderCriteria);
+                }
+                finally {
+                    latch.countDown();
+                }
+            });
+            futures.add(future);
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // Then
+        List<OrderResult> successfulOrders = new ArrayList<>();
+        for (Future<OrderResult> future : futures) {
+            try {
+                OrderResult result = future.get();
+                if (result != null) {
+                    successfulOrders.add(result);
+                }
+            } catch (Exception e) {
+
+            }
+        }
+
+        PointModel userPoint = pointRepository.findByUserId(USER_ID)
+            .orElseThrow(() -> new RuntimeException("포인트를 찾을 수 없습니다"));
+
+        // 주문 금액의 합계
+        long totalOrderAmount = successfulOrders.size() * PRODUCT_PRICE;
+
+        assertAll(
+            () -> assertThat(successfulOrders.size()).isGreaterThan(0),
+            // 포인트가 정확히 차감되었는지 확인
+            () -> assertThat(userPoint.getAmount().getAmount()).isEqualTo(INITIAL_POINT - totalOrderAmount)
+        );
+    }
+
+    @DisplayName("동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다")
+    @Test
+    void concurrentOrdersWithSameProduct() throws Exception {
+        // Given
+        final int numOfOrders = 50; // 동시에 50개 주문 시도
+        final long quantityPerOrder = 2L; // 각 주문당 구매할 수량
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numOfOrders);
+        CountDownLatch latch = new CountDownLatch(numOfOrders);
+        List<Future<OrderResult>> futures = new ArrayList<>();
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // When
+        for (int i = 0; i < numOfOrders; i++) {
+            Future<OrderResult> future = executorService.submit(() -> {
+                try {
+                    OrderCriteria.Order orderCriteria = new OrderCriteria.Order(
+                        USER_ID,
+                        List.of(new OrderCriteria.Order.OrderItem(productSku.getId(), quantityPerOrder)),
+                        null
+                    );
+                    OrderResult result = orderFacade.order(orderCriteria);
+                    successCount.incrementAndGet();
+                    return result;
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    return null;
+                } finally {
+                    latch.countDown();
+                }
+            });
+            futures.add(future);
+        }
+
+        latch.await(); // 모든 스레드가 완료될 때까지 대기
+        executorService.shutdown();
+
+        // Then
+        // 최종 재고 확인
+        InventoryModel inventory = inventoryRepository.find(productSku.getId())
+            .orElseThrow(() -> new RuntimeException("재고를 찾을 수 없습니다"));
+
+        // 성공한 주문의 총 수량
+        long totalOrderedQuantity = successCount.get() * quantityPerOrder;
+
+        assertAll(
+            () -> assertThat(successCount.get() + failCount.get()).isEqualTo(numOfOrders),
+            () -> assertThat(inventory.getQuantity().getQuantity()).isEqualTo(INITIAL_INVENTORY - totalOrderedQuantity),
+            // 재고 초과 주문이 있었다면 그 수량만큼 실패해야 함
+            () -> {
+                if (totalOrderedQuantity > INITIAL_INVENTORY) {
+                    assertThat(failCount.get()).isGreaterThan(0);
+                }
+            }
+        );
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderFacadeIntegrationTest.java
@@ -1,72 +1,328 @@
 package com.loopers.domain.order;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.loopers.application.order.OrderFacade;
 import com.loopers.application.order.dto.OrderCriteria;
-import com.loopers.application.order.dto.OrderCriteria.Order;
 import com.loopers.application.order.dto.OrderResult;
+import com.loopers.domain.coupone.dto.CouponCommand;
+import com.loopers.domain.coupone.dto.CouponInfo;
+import com.loopers.domain.coupone.entity.CouponPolicyModel;
+import com.loopers.domain.coupone.enums.DiscountType;
+import com.loopers.domain.coupone.repository.CouponPolicyRepository;
+import com.loopers.domain.coupone.repository.CouponRepository;
+import com.loopers.domain.coupone.service.CouponService;
 import com.loopers.domain.inventory.InventoryModel;
 import com.loopers.domain.inventory.repository.InventoryRepository;
-import com.loopers.domain.order.enums.OrderStatus;
 import com.loopers.domain.point.PointModel;
 import com.loopers.domain.point.repository.PointRepository;
+import com.loopers.domain.point.service.PointService;
 import com.loopers.domain.product.entity.ProductSkuModel;
 import com.loopers.domain.product.enums.SaleStatus;
 import com.loopers.domain.product.repository.ProductSkuRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import com.loopers.domain.coupone.entity.CouponModel;
+import com.loopers.domain.coupone.enums.CouponStatus;
+import com.loopers.domain.point.service.dto.PointCommand;
+import com.loopers.support.error.CoreException;
+import static org.junit.jupiter.api.Assertions.*;
+
+
 
 @SpringBootTest
 public class OrderFacadeIntegrationTest {
 
     @Autowired
     private OrderFacade orderFacade;
+
     @Autowired
     private ProductSkuRepository productSkuRepository;
+
     @Autowired
     private InventoryRepository inventoryRepository;
+
     @Autowired
     private PointRepository pointRepository;
 
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponPolicyRepository couponPolicyRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private static final Long USER_ID = 1L;
+    private static final Long INITIAL_POINT = 50000L;
+    private static final Long PRODUCT_PRICE = 10000L;
+    private static final Long INITIAL_INVENTORY = 10L;
+
+    private ProductSkuModel productSku;
+    private CouponInfo coupon;
+    private Long couponId;
+    private InventoryModel inventory;
+    private PointModel pointModel;
+
+    @BeforeEach
+    void setUp() {
+        // 상품 생성
+        productSku = ProductSkuModel.of(PRODUCT_PRICE, 0L, "색상", "RED", SaleStatus.ON_SALE, 1L);
+        productSku = productSkuRepository.save(productSku);
+
+        // 재고 생성
+        inventory = InventoryModel.of(INITIAL_INVENTORY, productSku.getId());
+        inventoryRepository.save(inventory);
+
+        // 포인트 생성
+        pointModel = PointModel.of(INITIAL_POINT, USER_ID);
+        pointRepository.save(pointModel);
+
+        // 쿠폰 정책 생성
+        CouponPolicyModel couponPolicy = CouponPolicyModel.of(
+            "테스트 쿠폰",
+            "테스트용 할인 쿠폰",
+            LocalDateTime.now().minusDays(1),
+            LocalDateTime.now().plusDays(30),
+            DiscountType.FIXED_AMOUNT,
+            10L, // 총 10개의 쿠폰
+            0,
+            5000, // 최대 5000원 할인
+            new BigDecimal("5000"), // 5000원 할인
+            10L // 초기 10개
+        );
+        couponPolicy = couponPolicyRepository.save(couponPolicy);
+
+        // 쿠폰 발급
+        coupon = couponService.issueCoupon(new CouponCommand.IssueCoupon(couponPolicy.getId(), USER_ID));
+        couponId = coupon.id();
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
     @DisplayName("주문을 생성할 때, ")
     @Nested
-    class Create {
+    class OrderPlace {
 
-        @DisplayName("정상적인 주문 생성 요청을 하면 주문 생성후 재고 차감 성공한다.")
+        @DisplayName("주문 성공 시, 모든 처리는 정상 반영되어야 한다")
         @Test
-        void when_validOrderRequestGiven_then_createOrder() {
-            Long orderQuantity = 10L;
-            Long inventoryQuantity = 100L;
-
-            // given
-            ProductSkuModel productSkuModel = ProductSkuModel.of(0L, "색상", "RED"
-                , SaleStatus.ON_SALE, 1L);
-            ProductSkuModel savedProductSkuModel = productSkuRepository.save(productSkuModel);
-
-            InventoryModel savedInventoryModel = inventoryRepository.save(InventoryModel.of(inventoryQuantity, savedProductSkuModel.getId()));
-            PointModel pointModel = PointModel.of(1000L, 1L);
-            pointRepository.save(pointModel);
-            pointRepository.increase(1L, 50000L);
-
-            Order order = new OrderCriteria.Order(
-                1L,
-                List.of(OrderItemModel.of(orderQuantity, 10L, savedProductSkuModel.getId())));
-            OrderResult saved = orderFacade.order(order);
-            // when
-
-            Long currentQuantity= inventoryRepository.find(savedProductSkuModel.getId()).get().getQuantity().getQuantity();
-            // then
-            assertAll(
-                () -> assertThat(saved.id()).isNotNull(),
-                () -> assertThat(saved.userId()).isEqualTo(pointModel.getRefUserId()),
-                () -> assertThat(currentQuantity).isEqualTo(inventoryQuantity - orderQuantity)
+        void orderSuccess_shouldUpdateAllResources() {
+            // Given
+            OrderCriteria.Order orderCriteria = new OrderCriteria.Order(
+                USER_ID,
+                List.of(new OrderCriteria.Order.OrderItem(productSku.getId(), 1L)),
+                couponId
             );
+
+            // When
+            OrderResult result = orderFacade.order(orderCriteria);
+
+            // Then
+            // 주문이 성공했는지 확인
+            assertNotNull(result);
+            assertNotNull(result.id());
+            assertEquals(USER_ID, result.userId());
+
+            // 재고가 차감되었는지 확인
+            InventoryModel updatedInventory = inventoryRepository.find(productSku.getId())
+                .orElseThrow(() -> new RuntimeException("재고를 찾을 수 없습니다"));
+            assertEquals(INITIAL_INVENTORY - 1, updatedInventory.getQuantity().getQuantity());
+
+            // 포인트가 차감되었는지 확인
+            PointModel updatedPoint = pointRepository.findByUserId(USER_ID)
+                .orElseThrow(() -> new RuntimeException("포인트를 찾을 수 없습니다"));
+
+            // 할인 금액 5000원을 적용하여 5000원만 차감되었는지 확인
+            assertEquals(INITIAL_POINT - (PRODUCT_PRICE - 5000), updatedPoint.getAmount().getAmount());
+
+            // 쿠폰이 사용되었는지 확인
+            CouponModel usedCoupon = couponRepository.find(couponId).get();
+            assertEquals(CouponStatus.USED, usedCoupon.getCouponStatus());
+            assertEquals(result.id(), usedCoupon.getOrderId());
         }
+
+        @DisplayName("사용 불가능한 쿠폰일 경우 주문은 실패해야 한다")
+        @Test
+        void orderWithInvalidCoupon_shouldFail() {
+            // Given
+            // 이미 사용된 쿠폰으로 만들기
+            couponService.useCoupon(new CouponCommand.UseCoupon(couponId, 999L, USER_ID));
+
+            OrderCriteria.Order orderCriteria = new OrderCriteria.Order(
+                USER_ID,
+                List.of(new OrderCriteria.Order.OrderItem(productSku.getId(), 1L)),
+                couponId
+            );
+
+            // When & Then
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                orderFacade.order(orderCriteria);
+            });
+            assertTrue(exception.getMessage().contains("사용할 수 없는 쿠폰입니다"));
+
+            // 재고와 포인트가 차감되지 않았는지 확인
+            InventoryModel unchangedInventory = inventoryRepository.find(productSku.getId()).orElseThrow();
+            assertEquals(INITIAL_INVENTORY, unchangedInventory.getQuantity().getQuantity());
+
+            PointModel unchangedPoint = pointRepository.findByUserId(USER_ID).orElseThrow();
+            assertEquals(INITIAL_POINT, unchangedPoint.getAmount().getAmount());
+        }
+
+        @DisplayName("재고가 부족할 경우 주문은 실패해야 한다")
+        @Test
+        void orderWithInsufficientInventory_shouldFail() {
+            // Given
+            OrderCriteria.Order orderCriteria = new OrderCriteria.Order(
+                USER_ID,
+                List.of(new OrderCriteria.Order.OrderItem(productSku.getId(), INITIAL_INVENTORY + 1)),
+                null
+            );
+
+            // When & Then
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                orderFacade.order(orderCriteria);
+            });
+            assertTrue(exception.getMessage().contains("재고가 부족합니다"));
+
+            // 포인트가 차감되지 않았는지 확인
+            PointModel unchangedPoint = pointRepository.findByUserId(USER_ID).orElseThrow();
+            assertEquals(INITIAL_POINT, unchangedPoint.getAmount().getAmount());
+
+            // 쿠폰이 사용되지 않았는지 확인
+            CouponModel unusedCoupon = couponRepository.find(couponId).orElseThrow();
+            assertEquals(CouponStatus.AVAILABLE, unusedCoupon.getCouponStatus());
+        }
+
+        @DisplayName("포인트가 부족할 경우 주문은 실패해야 한다")
+        @Test
+        void orderWithInsufficientPoint_shouldFail() {
+            // Given
+            pointService.usePoint(new PointCommand.UsePoint(USER_ID, INITIAL_POINT - 100));
+
+            OrderCriteria.Order orderCriteria = new OrderCriteria.Order(
+                USER_ID,
+                List.of(new OrderCriteria.Order.OrderItem(productSku.getId(), 1L)),
+                null
+            );
+
+            // When & Then
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                orderFacade.order(orderCriteria);
+            });
+            assertTrue(exception.getMessage().contains("금액이 부족 합니다."));
+
+
+            // 재고가 차감되지 않았는지 확인
+            InventoryModel unchangedInventory = inventoryRepository.find(productSku.getId()).orElseThrow();
+            assertEquals(INITIAL_INVENTORY, unchangedInventory.getQuantity().getQuantity());
+
+            // 쿠폰이 사용되지 않았는지 확인
+            CouponModel unusedCoupon = couponRepository.find(couponId).orElseThrow();
+            assertEquals(CouponStatus.AVAILABLE, unusedCoupon.getCouponStatus());
+        }
+
+        @DisplayName("존재하지 않는 쿠폰일 경우 주문은 실패해야 한다")
+        @Test
+        void orderWithNonExistentCoupon_shouldFail() {
+            // Given
+            Long nonExistentCouponId = 99999L;
+
+            OrderCriteria.Order orderCriteria = new OrderCriteria.Order(
+                USER_ID,
+                List.of(new OrderCriteria.Order.OrderItem(productSku.getId(), 1L)),
+                nonExistentCouponId
+            );
+
+            // When & Then
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                orderFacade.order(orderCriteria);
+            });
+            assertTrue(exception.getMessage().contains("쿠폰을 찾을 수 없습니다"));
+
+            // 재고와 포인트가 차감되지 않았는지 확인
+            InventoryModel unchangedInventory = inventoryRepository.find(productSku.getId()).orElseThrow();
+            assertEquals(INITIAL_INVENTORY, unchangedInventory.getQuantity().getQuantity());
+
+            PointModel unchangedPoint = pointRepository.findByUserId(USER_ID).orElseThrow();
+            assertEquals(INITIAL_POINT, unchangedPoint.getAmount().getAmount());
+        }
+
+        @DisplayName("존재하지 않는 상품으로 주문 시 실패해야 한다")
+        @Test
+        void orderWithNonExistentProduct_shouldFail() {
+            // Given
+            Long nonExistentProductId = 99999L;
+
+            OrderCriteria.Order orderCriteria = new OrderCriteria.Order(
+                USER_ID,
+                List.of(new OrderCriteria.Order.OrderItem(nonExistentProductId, 1L)),
+                null
+            );
+
+            // When & Then
+            Exception exception = assertThrows(Exception.class, () -> {
+                orderFacade.order(orderCriteria);
+            });
+
+            // 포인트가 차감되지 않았는지 확인
+            PointModel unchangedPoint = pointRepository.findByUserId(USER_ID).orElseThrow();
+            assertEquals(INITIAL_POINT, unchangedPoint.getAmount().getAmount());
+
+            // 쿠폰이 사용되지 않았는지 확인
+            CouponModel unusedCoupon = couponRepository.find(couponId).orElseThrow();
+            assertEquals(CouponStatus.AVAILABLE, unusedCoupon.getCouponStatus());
+        }
+
+
+
+//        @DisplayName("정상적인 주문 생성 요청을 하면 주문 생성후 재고 차감 성공한다.")
+//        @Test
+//        void when_validOrderRequestGiven_then_createOrder() {
+//            Long orderQuantity = 10L;
+//            Long inventoryQuantity = 100L;
+//
+//            // given
+//            ProductSkuModel productSkuModel = ProductSkuModel.of(0L,0L, "색상", "RED"
+//                , SaleStatus.ON_SALE, 1L);
+//            ProductSkuModel savedProductSkuModel = productSkuRepository.save(productSkuModel);
+//
+//            InventoryModel savedInventoryModel = inventoryRepository.save(InventoryModel.of(inventoryQuantity, savedProductSkuModel.getId()));
+//            PointModel pointModel = PointModel.of(1000L, 1L);
+//            pointRepository.save(pointModel);
+//            pointRepository.increase(1L, 50000L);
+//
+//            Order order = new OrderCriteria.Order(
+//                1L,
+//                List.of(new OrderItem(savedProductSkuModel.getId(), 10L)),
+//                null
+//            );
+//            OrderResult saved = orderFacade.order(order);
+//            // when
+//            Long currentQuantity= inventoryRepository.find(savedProductSkuModel.getId()).get().getQuantity().getQuantity();
+//            // then
+//            assertAll(
+//                () -> assertThat(saved.id()).isNotNull(),
+//                () -> assertThat(saved.userId()).isEqualTo(pointModel.getRefUserId()),
+//                () -> assertThat(currentQuantity).isEqualTo(inventoryQuantity - orderQuantity)
+//            );
+//        }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.loopers.domain.order.dto.OrderCommand;
+import com.loopers.domain.order.dto.OrderCommand.Order.OrderItem;
 import com.loopers.domain.order.dto.OrderInfo;
 import com.loopers.domain.order.enums.OrderStatus;
 import com.loopers.domain.order.service.OrderService;
@@ -29,7 +30,7 @@ public class OrderServiceIntegrationTest {
             // given
             OrderCommand.Order command = new OrderCommand.Order(
                 1L,
-                List.of(OrderItemModel.of(10L, 10L, 10L))
+                List.of(new OrderItem(10L, 10L, 10L))
             );
 
             // when

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.loopers.domain.point.repository.PointRepository;
+import com.loopers.domain.point.service.PointService;
+import com.loopers.domain.point.service.dto.PointCommand;
 import com.loopers.domain.user.BirthDate;
 import com.loopers.domain.user.Email;
 import com.loopers.domain.user.Gender;
@@ -16,21 +19,34 @@ import com.loopers.domain.user.dto.UserCommand;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 @SpringBootTest
 public class PointServiceIntegrationTest {
 
     @Autowired
-    private DatabaseCleanUp databaseCleanUp;
-    @Autowired
     private UserService userService;
 
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
 
     @AfterEach
     void tearDown() {
@@ -90,6 +106,7 @@ public class PointServiceIntegrationTest {
     @DisplayName("포인트 충전 시,")
     @Nested
     class ChargePoint {
+
         @DisplayName("존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.")
         @Test
         void whenChargePointWithNonExistentUser_thenFail() {
@@ -104,6 +121,238 @@ public class PointServiceIntegrationTest {
             // then
             assertAll(
                 () -> assertEquals(ErrorType.NOT_FOUND, coreException.getErrorType())
+            );
+        }
+    }
+
+
+    @DisplayName("동시에 포인트 사용 시,")
+    @Nested
+    class ConcurrencyUsePoint {
+
+        @DisplayName("비관적 락으로 인해 모든 요청이 순차적으로 처리된다")
+        @Test
+        void when_multipleConcurrentPointUsage_then_allRequestsProcessedSequentially() throws InterruptedException {
+            // Given
+            Long userId = 1L;
+            Long initialAmount = 10000L;
+            PointModel pointModel = PointModel.of(initialAmount, userId);
+            pointRepository.save(pointModel);
+
+            Long useAmount = 1000L;
+            int numberOfThreads = 5;
+
+            ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+            CountDownLatch readyLatch = new CountDownLatch(numberOfThreads);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch completionLatch = new CountDownLatch(numberOfThreads);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger exceptionCount = new AtomicInteger(0);
+
+            // When
+            for (int i = 0; i < numberOfThreads; i++) {
+                executorService.submit(() -> {
+                    try {
+                        readyLatch.countDown();
+                        startLatch.await();
+
+                        pointService.usePoint(new PointCommand.UsePoint(userId, useAmount));
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        exceptionCount.incrementAndGet();
+                    } finally {
+                        completionLatch.countDown();
+                    }
+                });
+            }
+
+            readyLatch.await();
+            startLatch.countDown();
+            completionLatch.await();
+            executorService.shutdown();
+
+            // Then
+            PointModel updatedPoint = pointRepository.findByUserId(userId).orElseThrow();
+            Long finalAmount = updatedPoint.getAmount().getAmount();
+
+            assertAll(
+                // 모든 요청이 성공해야 함
+                () -> assertThat(successCount.get()).isEqualTo(numberOfThreads),
+                // 예외는 발생하지 않아야 함
+                () -> assertThat(exceptionCount.get()).isEqualTo(0),
+                // 최종 포인트는 모든 요청이 처리된 금액
+                () -> assertThat(finalAmount).isEqualTo(initialAmount - (numberOfThreads * useAmount))
+            );
+        }
+    }
+
+
+    @DisplayName("동시에 포인트 충전 시,")
+    @Nested
+    class ConcurrencyChargePoint {
+
+        @DisplayName("비관적 락을 사용하여 모든 충전 요청이 순차적으로 처리된다")
+        @Test
+        void when_multipleConcurrentPointCharge_then_allRequestsProcessedSequentially() throws InterruptedException {
+            // Given
+            // 포인트 초기화
+            Long userId = 1L;
+            Long initialAmount = 0L;
+            PointModel pointModel = PointModel.of(initialAmount, userId);
+            pointRepository.save(pointModel);
+
+            // 동시에 충전할 포인트 금액
+            Long chargeAmount = 1000L;
+
+            // 여러 스레드로 동시에 포인트 충전 요청
+            int numberOfThreads = 5; // 동시 요청 수
+            ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+            CountDownLatch readyLatch = new CountDownLatch(numberOfThreads); // 모든 스레드가 준비될 때까지 대기
+            CountDownLatch startLatch = new CountDownLatch(1); // 시작 신호를 위한 래치
+            CountDownLatch completionLatch = new CountDownLatch(numberOfThreads); // 모든 스레드가 완료될 때까지 대기
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger exceptionCount = new AtomicInteger(0);
+
+            // When
+            for (int i = 0; i < numberOfThreads; i++) {
+                executorService.submit(() -> {
+                    try {
+                        // 준비 완료 신호
+                        readyLatch.countDown();
+                        // 모든 스레드가 동시에 시작하도록 대기
+                        startLatch.await();
+
+                        // 포인트 충전 요청
+                        pointService.chargePoint(new PointCommand.ChargePoint(userId, chargeAmount));
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        exceptionCount.incrementAndGet();
+                    } finally {
+                        completionLatch.countDown();
+                    }
+                });
+            }
+
+            // 모든 스레드가 준비될 때까지 대기
+            readyLatch.await();
+            // 모든 스레드에게 시작 신호
+            startLatch.countDown();
+            // 모든 스레드가 완료될 때까지 대기
+            completionLatch.await();
+            executorService.shutdown();
+
+            // Then
+            // 최종 포인트 조회
+            PointModel updatedPoint = pointRepository.findByUserId(userId).orElseThrow();
+            Long finalAmount = updatedPoint.getAmount().getAmount();
+
+            assertAll(
+                // 비관적 락을 사용하면 모든 요청이 성공해야 함
+                () -> assertThat(successCount.get()).isEqualTo(numberOfThreads),
+                // 예외는 발생하지 않아야 함
+                () -> assertThat(exceptionCount.get()).isEqualTo(0),
+                // 최종 포인트는 초기 금액에 모든 충전 금액이 더해져야 함
+                () -> assertThat(finalAmount).isEqualTo(initialAmount + (chargeAmount * numberOfThreads))
+            );
+        }
+    }
+
+
+    @DisplayName("동시에 포인트 충전 과 사용 시,")
+    @Nested
+    class ConcurrencyChargeAndUsePoint {
+        @DisplayName("한번만 성공하고 나머지 ObjectOptimisticLockingFailureException가 발생한다")
+        @Test
+        void when_concurrentChargeAndUsePoint_then_bothRequestsProcessedSequentially() throws InterruptedException {
+            // Given
+            // 포인트 초기화 (사용자 포인트 생성)
+            Long userId = 1L;
+            Long initialAmount = 1000L;
+            PointModel pointModel = PointModel.of(initialAmount, userId);
+            pointRepository.save(pointModel);
+
+            // 동시에 발생할 충전 금액과 사용 금액
+            Long chargeAmount = 500L;
+            Long useAmount = 300L;
+
+            // 두 개의 스레드로 동시에 충전과 사용 요청
+            int numberOfThreads = 2; // 충전 1개, 사용 1개
+            ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+            CountDownLatch readyLatch = new CountDownLatch(numberOfThreads); // 모든 스레드가 준비될 때까지 대기
+            CountDownLatch startLatch = new CountDownLatch(1); // 시작 신호를 위한 래치
+            CountDownLatch completionLatch = new CountDownLatch(numberOfThreads); // 모든 스레드가 완료될 때까지 대기
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+            AtomicBoolean chargeSuccess = new AtomicBoolean(false);
+            AtomicBoolean useSuccess = new AtomicBoolean(false);
+
+            // When
+            // 충전 스레드
+            executorService.submit(() -> {
+                try {
+                    // 준비 완료 신호
+                    readyLatch.countDown();
+                    // 모든 스레드가 동시에 시작하도록 대기
+                    startLatch.await();
+
+                    // 포인트 충전 요청
+                    pointService.chargePoint(new PointCommand.ChargePoint(userId, chargeAmount));
+                    successCount.incrementAndGet();
+                    chargeSuccess.set(true);
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+
+            // 사용 스레드
+            executorService.submit(() -> {
+                try {
+                    // 준비 완료 신호
+                    readyLatch.countDown();
+                    // 모든 스레드가 동시에 시작하도록 대기
+                    startLatch.await();
+
+                    // 포인트 사용 요청
+                    pointService.usePoint(new PointCommand.UsePoint(userId, useAmount));
+                    successCount.incrementAndGet();
+                    useSuccess.set(true);
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+
+            // 모든 스레드가 준비될 때까지 대기
+            readyLatch.await();
+            // 모든 스레드에게 시작 신호
+            startLatch.countDown();
+            // 모든 스레드가 완료될 때까지 대기
+            completionLatch.await();
+            executorService.shutdown();
+
+            // Then
+            // 최종 포인트 조회
+            PointModel updatedPoint = pointRepository.findByUserId(userId).orElseThrow();
+            Long finalAmount = updatedPoint.getAmount().getAmount();
+
+            // 비관적 락을 사용하면 두 요청 모두 성공해야 함
+            assertAll(
+                // 두 요청 모두 성공
+                () -> assertThat(successCount.get()).isEqualTo(2),
+                // 실패 없음
+                () -> assertThat(failCount.get()).isEqualTo(0),
+                // 충전 성공
+                () -> assertThat(chargeSuccess.get()).isTrue(),
+                // 사용 성공
+                () -> assertThat(useSuccess.get()).isTrue(),
+                // 최종 포인트는 초기 금액 + 충전 금액 - 사용 금액
+                () -> assertThat(finalAmount).isEqualTo(initialAmount + chargeAmount - useAmount)
             );
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/coupon/CouponPolicyV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/coupon/CouponPolicyV1ApiE2ETest.java
@@ -1,0 +1,108 @@
+package com.loopers.interfaces.coupon;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.CreateRequest;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.CreateResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.GetCouponPolicyResponse;
+import com.loopers.interfaces.api.coupon.CouponPolicyV1Dto.SummaryListResponse;
+import com.loopers.support.pagenation.PageResult;
+import com.loopers.support.pagenation.Pageable;
+import com.loopers.utils.DatabaseCleanUp;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CouponPolicyV1ApiE2ETest {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("POST /api/v1/coupon-policy")
+    @Nested
+    class Create {
+
+        private static final Function<String, String> ENDPOINT = pathVariable -> "/api/v1/coupon-policy" + pathVariable;
+
+        @DisplayName("쿠폰 정책 생성 요청을 하면 , 200 OK 응답을 리턴한다.")
+        @Test
+        void when_createCouponPolicy_then_returnOk() {
+            String requestUrl = ENDPOINT.apply("");
+            CreateRequest request = new CreateRequest(
+
+            );
+
+            ParameterizedTypeReference<ApiResponse<CreateResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+
+            ResponseEntity<ApiResponse<CreateResponse>> actual =
+                testRestTemplate.exchange(requestUrl, HttpMethod.POST, new HttpEntity<>(request), responseType);
+
+            assertTrue(actual.getStatusCode().is2xxSuccessful());
+        }
+    }
+
+
+    @DisplayName("GET /api/v1/coupon-policy/{couponId}")
+    @Nested
+    class GetCouponPolicy {
+
+        private static final Function<Long, String> ENDPOINT = id -> "/api/v1/coupon-policy/" + id;
+
+        @DisplayName("쿠폰 정책 조회에 성공하면, 쿠폰 정책 정보를 반환한다.")
+        @Test
+        void when_createCouponPolicy_then_returnOk() {
+            Long request = 1L;
+            String requestUrl = ENDPOINT.apply(request);
+
+            ParameterizedTypeReference<ApiResponse<GetCouponPolicyResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+
+            ResponseEntity<ApiResponse<GetCouponPolicyResponse>> actual =
+                testRestTemplate.exchange(requestUrl, HttpMethod.GET, new HttpEntity<>(request), responseType);
+
+            assertTrue(actual.getStatusCode().is2xxSuccessful());
+        }
+    }
+
+    @DisplayName("GET /api/v1/coupon-policy")
+    @Nested
+    class GetCouponPolicies {
+
+        private static final Function<String, String> ENDPOINT = pathVariable -> "/api/v1/coupon-policy" + pathVariable;
+
+        @DisplayName("쿠폰 정책을 목록 조회에 성공하면, 쿠폰 정책을 목록 정보를 반환한다.")
+        @Test
+        void when_createCouponPolicy_then_returnOk() {
+            Pageable request = new Pageable();
+            String requestUrl = ENDPOINT.apply("");
+
+            ParameterizedTypeReference<ApiResponse<PageResult<SummaryListResponse>>> responseType = new ParameterizedTypeReference<>() {
+            };
+
+            ResponseEntity<ApiResponse<PageResult<SummaryListResponse>>> actual =
+                testRestTemplate.exchange(requestUrl, HttpMethod.GET, new HttpEntity<>(request), responseType);
+
+            assertTrue(actual.getStatusCode().is2xxSuccessful());
+        }
+    }
+}

--- a/docs/design/04-erd.md
+++ b/docs/design/04-erd.md
@@ -4,20 +4,23 @@
 ---
 ---
 config:
-  theme: default
-  layout: dagre
-  look: handDrawn
+theme: default
+layout: dagre
+look: classic
 ---
 erDiagram
     USER ||--o| POINT: ""
     POINT ||--|{ POINT_HISTORY: ""
-    USER ||--o{ PRODUCT_LIKE: ""
-    PRODUCT ||--o{ PRODUCT_LIKE: ""
+    USER ||--o{ LIKE: ""
+    PRODUCT ||--o{ LIKE: ""
     PRODUCT ||--o| INVENTORY: ""
-    PRODUCT ||--o{ ORDER_PRODUCT: ""
+    PRDUCT_SKU ||--o{ ORDER_PRODUCT: ""
+    PRODUCT ||--o{ PRDUCT_SKU : ""
     USER ||--o{ ORDER: ""
     ORDER ||--|{ ORDER_PRODUCT: ""
     ORDER ||--|| PAYMENT: ""
+    COUPON_POLICY ||--o{ COUPON : ""
+    USER ||--o{ COUPON: ""
     USER {
         BIGINT id PK "사용자 ID"
         VARCHAR login_id "로그인 ID"
@@ -91,14 +94,56 @@ erDiagram
         TIMESTAMP updated_at "수정일시"
         TIMESTAMP deleted_at "삭제일시"
     }
-    PRODUCT_LIKE {
+    LIKE {
 		BIGINT id PK "좋아요 ID"
 		BIGINT ref_user_id FK "사용자 ID"
-        BIGINT ref_product_id FK "상품 ID"
+        BIGINT target_id FK "타겟 ID"
 		timestamp is_like "좋아요 여부"
 		TIMESTAMP created_at "생성일시"
         TIMESTAMP updated_at "수정일시"
         TIMESTAMP deleted_at "삭제일시"
 	}
+    PRDUCT_SKU {
+        BIGINT id PK "SKU ID"
+        decimal price "기본 가격"
+        decimal additional_price "추가 가격"
+        varchar option_type "옵션 종류"
+        varchar option_value "옵션 값"
+        enum sale_status "판매 상태"
+        bigint ref_product_id FK "Product ID"
+         TIMESTAMP created_at "생성일시"
+        TIMESTAMP updated_at "수정일시"
+        TIMESTAMP deleted_at "삭제일시"
+    }
+    COUPON_POLICY {
+        BIGINT id PK "쿠폰 정책 ID"
+        varchar name "쿠폰 정책 이름"
+        varchar description "쿠폰 정책 설명"
+        enum discount_type "할인 타입 (FIXED_AMOUNT | PERCENTAGE)"
+        decimal discount_value "할인 값"
+        int maximum_discount_amount "최대 할인 금액"
+        int minimum_order_amount "최소 주문 금액"
+        bigint total_quantity "총 수량"
+        bigint remain_quantity "남은 수량"
+        datetime start_time "시작 시간"
+        datetime end_time "종료 시간"
+        TIMESTAMP created_at "생성일시"
+        TIMESTAMP updated_at "수정일시"
+        TIMESTAMP deleted_at "삭제일시"
+    }
+    COUPON {
+        BIGINT id PK "쿠폰 ID"
+        bigint ref_coupon_policy_id FK "coupon_policy 참조"
+        bigint ref_user_id "사용자 ID"
+        bigint ref_order_id "주문 ID"
+        enum coupon_status "AVAILABLE | CANCELED | EXPIRED | USED"
+        datetime issued_at "발급일"
+        datetime expiration_time "만료일"
+        datetime used_at "사용일"
+        TIMESTAMP created_at "생성일시"
+        TIMESTAMP updated_at "수정일시"
+        TIMESTAMP deleted_at "삭제일시" 
+    }
+
 
 ```


### PR DESCRIPTION
## 📌 Summary
- Coupon 도메인**모델링**
- **주문** 흐름에 대해 원자성 보장
- 동시성 테스트(상품 좋아요, 재고 차감, 쿠폰 발급, 포인트 차감)
- 
## 💬 Review Points

쿠폰/재고/포인트 등의 **도메인 모델 설계와 동시성 제어 전략**을 정리하고, 실험적으로 적용한 방식을 바탕으로 **비관적 락 / 낙관적 락 / 락 없는 처리**의 기준을 세워보고자 했습니다.

동시성 이슈가 발생할 수 있는 주요 도메인에 대해 아래와 같이 구현했습니다:

- 포인트 차감: **비관적 락**
- 좋아요: **DB 제약조건 + 예외 처리 (락 없음)**
- 쿠폰 발급: **비관적 락 + remain_quantity 컬럼 관리**
- 재고 감소: **비관적 락 + 조건부 원자적 업데이트**

이 과정에서 실제 운영 관점에서 부족한 점이나, 더 나은 접근 방식이 있을지 궁금해 피드백을 받고 싶습니다.

---

## 🔒 **동시성 제어 전략에 대한 고민**

### 1. 포인트 차감 - **비관적 락**

초기에는 `@Version`을 활용한 **낙관적 락 기반 설계**로 시작했습니다.

그 이유는 아래와 같았습니다:

- 포인트 차감 시, 동시 접근이 발생해도 먼저 커밋된 트랜잭션 외에는 예외를 발생시키고 **빠르게 실패**시키면 되지 않을까 생각했습니다.
- **재시도 로직**을 붙여서 다시 요청하게 하면 자연스럽게 충돌을 해소할 수 있다고 판단했었습니다.

그런데 실제 비즈니스 요구사항은 다음과 같았습니다:

> "동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 합니다."
> 
> 
> (예: 사용자가 PC와 모바일에서 동시에 주문 시도)
> 

낙관적 락을 사용할 경우, 하나의 트랜잭션만 성공하고 나머지는 버전 충돌로 실패하므로,

 결국 `PESSIMISTIC_WRITE` 비관적 락으로 전환했습니다.

- 포인트 테이블에 대해 먼저 락을 획득한 후 차감을 수행
- **동시 요청도 순차적으로 처리되며, 충돌 없이 모두 정상 처리 가능**
- 성능 이슈가 우려되긴 하지만, **정합성을 우선**이라는 판단이었습니다.

> Q.  이와 같은 상황에서 비관적 락이 최선이라고 보실까요?
> 
> 
> 혹시 더 나은 방식이 있다면 조언 부탁드립니다.
> 
> Q. 성공 보장이 필수인 도메인에선 비관적 락이 최선일까요?
> 
> 더 나은 UX/성능 균형 전략이 있다면 알려주시면 감사하겠습니다.
> 

### 2. 좋아요 - **락 없이 처리 (DB 제약조건 기반)**

**비관적/낙관적 락 대신, 아래와 같이 중복 방어 방식으로 처리했습니다.**

- `userId`, `targetId`, `likeType` 조합에 **DB Unique 제약조건 설정**
- 먼저 존재 여부를 확인하고 저장 시도 (`exists → save`)
- 중복 저장 시 `DataIntegrityViolationException` 발생 → 무시 처리
- 트랜잭션은 `@Transactional(noRollbackFor = ...)`로 **롤백 방지**

```java
if (likeRepository.isExists(...)) return;

try {
    likeRepository.save(like);
} catch (DataIntegrityViolationException e) {
    // 중복은 무시
}
```

삭제는 단순한 조건 기반의 JPQL `DELETE`로 처리했고, 별도의 락은 사용하지 않았습니다.
### 구현 예시

```java
@Transactional
public void unlike(LikeCommand.Unlike command) {
    likeRepository.deleteWithLock(command.userId(), command.targetId(), command.likeType());
}

@Modifying
@Query("""
    DELETE FROM LikeModel l
    WHERE l.userId = :userId
      AND l.targetId = :targetId
      AND l.likeType = :likeType
""")
void deleteWithLock(@Param("userId") Long userId,
                    @Param("targetId") Long targetId,
                    @Param("likeType") LikeType likeType);

```


별도의 락이나 버전 관리 없이도, 단순 조건 기반 삭제로 **동시성 이슈 없이** 처리가 가능하다고 생각합니다.


> Q. 실무에서도 이렇게 락 없이 처리하는 방식이 괜찮을까요?
> 
> 
> 혹시 놓치고 있는 위험요소가 있다면 알려주시면 감사하겠습니다.
> 

### 3. 쿠폰 발급 설계 - **비관적 락 + remain_quantity 컬럼 설정**

**쿠폰 발급 로직에서 동시성 문제**를 겪은 후, 이를 해결하기 위해 구조를 변경했는데,

혹시 더 나은 방식이나 보완할 점이 있을지 조언을 부탁드리고자 정리해봤습니다.

**기존 설계 방식**

초기에는 `coupon_policy` 테이블에 **남은 수량(`remain_quantity`)을 별도로 두지 않고**,

매번 `coupon` 테이블을 **COUNT 쿼리**로 조회해서 발급 가능 여부를 판단했습니다.

**쿠폰 발급 절차는 다음과 같았습니다:**

1. `coupon_policy`를 **비관적 락(PESSIMISTIC_WRITE)** 으로 조회
2. 해당 정책에 대해 **현재 발급된 쿠폰 수량을 COUN**
3. `total_quantity`보다 적으면 쿠폰 발급

```sql
SELECT COUNT(*) FROM coupon WHERE ref_coupon_policy_id = ?
```

**동시에 여러 요청이 들어올 때 문제가 발생했습니다.**

- 거의 동시에 여러 트랜잭션이 **같은 시점에 쿠폰 수량이 충분하다고 판단**
- 각각 **쿠폰을 발급하면서, 총 발급 수량을 초과하는 상황 발생**
- 결국 **동시성 문제가 생기고, 정합성이 깨짐**

---

**구조 변경: remain_quantity 컬럼 추가**

이 문제를 해결하기 위해 `coupon_policy` 테이블에 **`remain_quantity` 컬럼을 추가**했습니다.

**변경후 로직**

1. 쿠폰 정책을 `PESSIMISTIC_WRITE`로 조회해 락을 걸고
2. `remain_quantity`를 직접 확인한 뒤
3. 발급 가능하면 수량을 차감하고, 쿠폰을 생성

즉, **COUNT 대신 `remain_quantity` 컬럼 차감으로 원자성을 확보**하려는 시도였습니다.

```java
// 조회 시 락
@Lock(LockModeType.PESSIMISTIC_WRITE)
@Query("SELECT cp FROM CouponPolicyModel cp WHERE cp.id = :id")
Optional<CouponPolicyModel> findByIdWithLock(@Param("id") Long id);

// 차감
@Modifying
@Query("UPDATE CouponPolicyModel cp "
    + "SET cp.remainQuantity.quantity = cp.remainQuantity.quantity - 1 "
    + "WHERE cp.id = :id  AND cp.remainQuantity.quantity > 0 ")
int decreaseRemainQuantity(@Param("id") Long id);
```

이렇게 하니, **트랜잭션 경합 상황에서도 수량 초과 없이 동작**했습니다.

---

> **Q1. 비관적 락을 사용했는데도 COUNT 기반으로는 정합성이 깨졌습니다.**
> 
> 
> 이 현상이 발생한 이유를 정확히 이해한 건지 확인받고 싶습니다.
> 

> Q2. remain_quantity 컬럼을 직접 관리하는 방식이 더 좋은 구조일까요?
> 
> 
> 혹시 이 방식에서도 놓치기 쉬운 동시성 문제나, 다른 트레이드오프가 있다면 알고 싶습니다.
> 

> Q3. 실무에서 쿠폰 같은 선착순 리소스를 다룰 때 더 많이 쓰는 전략이 있을까요?
> 

---

### 4. **쿠폰 차감** - **비관적 락 + remain_quantity 컬럼 원자적 업데이트 조합**

### 현재 구현 방식

```java
// 1. 비관적 락으로 쿠폰 정책 조회
@Lock(LockModeType.PESSIMISTIC_WRITE)
Optional<CouponPolicyModel> findByIdWithLock(Long id);

// 2. 조건부 원자적 업데이트로 수량 차감
@Modifying
@Query("UPDATE CouponPolicyModel cp " +
       "SET cp.remainQuantity.quantity = cp.remainQuantity.quantity - 1 " +
       "WHERE cp.id = :id AND cp.remainQuantity.quantity > 0")
int decreaseRemainQuantity(@Param("id") Long id);
```

- 먼저 **락을 걸고 쿠폰 정책을 조회**한 뒤,
- **JPQL 쿼리로 수량을 원자적으로 차감**하고 있습니다.
- `remainQuantity > 0` 조건으로 인해 **DB 차원에서 선착순 제어가 가능**하며,
- 쿼리 결과(`int`)를 통해 발급 성공 여부를 판단하고 있습니다.

**이렇게 개선해봐도 괜찮을까요?**

현재는 락을 걸고 수량을 차감하는 구조인데, 아래처럼 **락 없이 원자적 UPDATE만으로 처리**해도 괜찮을지 궁금합니다:

```java
@Transactional
public boolean issueCoupon(Long couponPolicyId, Long userId) {
    int updatedRows = couponPolicyRepository.decreaseRemainQuantity(couponPolicyId);

    if (updatedRows == 0) {
        return false; // 수량 부족 or 유효기간 만료
    }

    couponRepository.save(Coupon.issue(couponPolicyId, userId));
    return true;
}
```

- 락을 생략하고, **JPQL UPDATE 쿼리 하나로만 처리**
- **성능 면에서는 더 유리할 것 같은데**,혹시 이렇게 바꿔도 **실제 운영에서 문제가 발생할 여지가 있을지** 조언을 듣고 싶습니다.

> 혹시 이 방식에도 데이터 정합성이나 경합 측면에서 리스크가 있을까요?
> 

---

### 4. 재고 감소 - **비관적 락 + 이중 검증**

```java
@Transactional
public void decrease(InventoryCommand.DecreaseStock command) {
    // 1. 비관적 락으로 재고 조회 및 검증
    InventoryModel inventoryModel = inventoryRepository.findWithLock(command.productSkuId())
        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "재고가 존재하지 않습니다."));

    if (inventoryModel.getQuantity().getQuantity() < command.quantity()) {
        throw new CoreException(ErrorType.BAD_REQUEST, "재고가 부족합니다.");
    }

    // 2. 원자적 업데이트로 재고 차감
    int decreasedCount = inventoryRepository.decreaseStock(command.productSkuId(), command.quantity());

    if (decreasedCount == 0) {
        throw new CoreException(ErrorType.BAD_REQUEST, "재고가 부족합니다.");
    }

```

**Repository 레이어는 아래와 같이 구성했습니다:**

```java

// 비관적 락 조회
@Lock(LockModeType.PESSIMISTIC_WRITE)
@Query("SELECT i FROM InventoryModel i WHERE i.refProductSkuId = :productSkuId")
Optional<InventoryModel> findWithLock(Long productSkuId);

// 원자적 차감
@Modifying
@Query("UPDATE InventoryModel i "
    + "SET i.quantity.quantity = i.quantity.quantity - :quantity "
    + "WHERE i.refProductSkuId = :productSkuId "
    + "AND i.quantity.quantity >= :quantity")
int decreaseStock(Long productSkuId, Long quantity);
```

**고민되는 지점**

 **1. 재고 부족 검증을 두 번 하는 구조가 과연 필요한가요?**

현재는 **애플리케이션 레벨과 DB 레벨**에서 **이중 검증**을 하고 있습니다:

- **Step 1:** 조회 후 수량 비교 (Java 코드)
- **Step 2:** 원자적 업데이트 시 `WHERE` 조건에서 재고 체크

> Q1.이 검증을 둘 다 해야 할까요?
> 
> 
> `UPDATE ... WHERE quantity >= :quantity` 만으로도 충분히 방어 가능한 것 같은데,
> 
> 굳이 애플리케이션 단에서 먼저 체크하는 것이 오히려 낭비일 수도 있겠다 싶어서요.
> 

---

 **2. 비관적 락에 대한 성능 우려**

**한정 상품이나 이벤트 상품**의 경우, 아주 짧은 시간 내에 많은 요청이 몰릴 수 있습니다.

현재는 **비관적 락 (`PESSIMISTIC_WRITE`)을 사용해서 조회하고**, 그 후 업데이트하는 방식이라 성능 병목이 생길 가능성이 있고 DB 락 대기가 사용자 경험을 떨어뜨릴 수 있습니다

> Q2.  이 상황에서는 낙관적 락이 더 적절할 수 있을까요?
> 
> 
> 아니면, `UPDATE ... WHERE quantity >= :quantity` 만으로 처리하고
> 
> 실패 시 예외 처리 + 재시도 방식이 더 나을까요?
> 

---

### 5.낙관적 락 선택에 대한고민

현재 대부분 비관적 락 기반으로 처리하고 있습니다.

실패 허용이 어렵고 정합성 보장이 중요한 도메인이 많다 보니 자연스럽게 그렇게 선택하게 됐습니다.

그런데 **낙관적 락은 언제 쓰는 게 진짜 적절한지 여전히 기준이 잘 안 잡힙니다.**

제가 정리한 기준은 다음과 같습니다:

- 낙관적 락은 **실패를 감수하고 빠르게 피드백을 주는 상황**에서만 쓴다
- **리트라이 전략 없이 빠른 실패**가 곧바로 UX로 이어져도 괜찮은 도메인에서만 선택
- 예:  어드민 기능, 자기 자신 정보 변경 등

> **Q. 이 기준이 적절한 방향일까요?**
혹시 낙관적 락을 더 넓게 활용할 수 있는 케이스가 있다면 알려주시면 감사하겠습니다.
> 


PS. 지금까지 긴 글 읽어주셔서 정말 감사합니다.
낙관적 락과 비관적 락에 대해 잘 몰랐는데, 개념을 쉽고 명확하게 설명해주셔서 정말 큰 도움이 되었습니다 🙏
동시성 이슈도 그동안 막연하게만 알고 있었고, 실제로 겪어본 적이 없어서 어떤 상황에서 주로 발생하는지조차 몰랐는데, 그런 부분들을 알기 쉽게 풀어주셔서 많은 인사이트를 얻었습니다.
항상 핵심을 잘 짚어주시는 설명과 실무적인 예시 덕분에 공부가 더 재미있어지고 집중할 수 있었습니다. 남은 과정도 끝까지 최선을 다해 따라가겠습니다. 감사합니다! 😊

회사 코드에 락 걸 생각만 해도 벌써부터 기분이 좋네요!
이제 동시성 이슈도 자신 있게 다룰 수 있을 것 같아 기대가 큽니다.